### PR TITLE
Add `tf.distribute.DistributeStrategy.scope()` to computation

### DIFF
--- a/bin/dev-lint
+++ b/bin/dev-lint
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/../dev
+
+REQUIRES=(ROOT_DIR)
+check_requires ${REQUIRES[@]}
+
+python3 -m venv .venv
+source $ROOT_DIR/.venv/bin/activate
+
+black kormos tests
+exit $?

--- a/kormos/models.py
+++ b/kormos/models.py
@@ -60,276 +60,290 @@ logger = logging.getLogger(__name__)
 
 
 class BatchOptimizedModel(keras.Model):
-  """
-  A `keras.Model` allowing parameter optimization by *either* stochastic *or* 
-  deterministic (full batch) algorithms.
-  
-  Stochastic optimization may be performed on a `BatchOptimizedModel` using the
-  standard optimizers in `keras.optimizers.*` or by using a `kormos.optimizers.BatchOptimizer`.
-  The `optimizer` argument to the model's `compile` method will determine which
-  training procedure should be used.
-
-  For instance, the same model may be optimized either by SGD or by L-BFGS-B as follows: 
-
-  .. code-block:: python
-
-    from tensorflow import keras
-    from kormos.models import BatchOptimizedSequentialModel
-
-    # Create an Ordinary Least Squares regressor
-    model = BatchOptimizedSequentialModel()
-    model.add(keras.layers.Dense(
-      units=1,
-      input_shape=(5,),
-    ))
-
-    # compile the model for stochastic optimization
-    model.compile(loss=keras.losses.MeanSquaredError(), optimizer="sgd")
-    model.fit(...)
-
-    # compile the model for deterministic optimization using scipy.optimize.minimize
-    model.compile(loss=keras.losses.MeanSquaredError(), optimizer="L-BFGS-B")
-    model.fit(...)
-
-  """
-
-  def compile(self, **kwargs):
     """
-    Configure the model for training.
+    A `keras.Model` allowing parameter optimization by *either* stochastic *or*
+    deterministic (full batch) algorithms.
 
-    If the `optimizer` argument is specified as one of the `keras.optimizers.*`
-    (or a string identifier thereby), then this method will simply call the
-    parent method `keras.Model.compile` with the arguments provided.
-    Subsequent calls to the `model.fit` will perform training using the 
-    standard `keras.Model.fit` method.
+    Stochastic optimization may be performed on a `BatchOptimizedModel` using the
+    standard optimizers in `keras.optimizers.*` or by using a `kormos.optimizers.BatchOptimizer`.
+    The `optimizer` argument to the model's `compile` method will determine which
+    training procedure should be used.
 
-    If the `optimizer` argument is specified as a valid `kormos.optimizers.BatchOptimizer`
-    (or a valid string identifier to create one using `kormos.optimizers.get()`), then
-    the model will be configured to map calls to `fit` to the method `fit_batch`. 
+    For instance, the same model may be optimized either by SGD or by L-BFGS-B as follows:
 
-    Keyword Args:
-      optimizer: A `keras.optimizer.Optimizer` or string identifier, or a `kormos.optimizer.BatchOptimizer` or string identifier  
-      **kwargs: all other `kwargs` as passed to `keras.Model.compile <https://keras.io/api/models/model_training_apis/#compile-method>`_
+    .. code-block:: python
+
+      from tensorflow import keras
+      from kormos.models import BatchOptimizedSequentialModel
+
+      # Create an Ordinary Least Squares regressor
+      model = BatchOptimizedSequentialModel()
+      model.add(keras.layers.Dense(
+        units=1,
+        input_shape=(5,),
+      ))
+
+      # compile the model for stochastic optimization
+      model.compile(loss=keras.losses.MeanSquaredError(), optimizer="sgd")
+      model.fit(...)
+
+      # compile the model for deterministic optimization using scipy.optimize.minimize
+      model.compile(loss=keras.losses.MeanSquaredError(), optimizer="L-BFGS-B")
+      model.fit(...)
+
     """
-    optimizer_orig = kwargs.pop("optimizer", "rmsprop")
-    use_batch_fit = False
-    try:
-      optimizer = keras.optimizers.get(optimizer_orig)
-      logger.warning(f"BatchOptimizedModel compiled with optimizer={optimizer}.")
-    except ValueError:
-      # A BatchOptimizer or its string identifier will raise a ValueError,
-      # in which case we know to fit this model using .fit_batch()
-      optimizer = "rmsprop"  # Set a valid default to call .compile() as a dummy
-      use_batch_fit = True
 
-    super().compile(optimizer=optimizer, **kwargs)
-    # If we are fitting with a deterministic batch algorithm, reset
-    # the optimizer to the desired one after compilation
-    if use_batch_fit:
-      self.optimizer = kormos.optimizers.get(optimizer_orig)
-      self.fit = self.fit_batch
+    def compile(self, **kwargs):
+        """
+        Configure the model for training.
 
-  @traceback_utils.filter_traceback
-  def fit_batch(
-      self,
-      x=None,
-      y=None,
-      batch_size=None,
-      epochs=20,
-      verbose='auto',
-      callbacks=None,
-      validation_split=0.,
-      validation_data=None,
-      shuffle=False,
-      class_weight=None,
-      sample_weight=None,
-      initial_epoch=0,
-      steps_per_epoch=None,
-      validation_steps=None,
-      validation_batch_size=None,
-      validation_freq=1,
-      max_queue_size=10,
-      workers=1,
-      use_multiprocessing=False,
-      pretrain_fn=None,
-      **kwargs
-    ):
-    """
-    Train the model using a batch optimization algorithm for up to the maximum number 
-    of iterations (`epochs`), and return the optimization history object.
+        If the `optimizer` argument is specified as one of the `keras.optimizers.*`
+        (or a string identifier thereby), then this method will simply call the
+        parent method `keras.Model.compile` with the arguments provided.
+        Subsequent calls to the `model.fit` will perform training using the
+        standard `keras.Model.fit` method.
 
-    This method will prepare the training dataset and execution context, and then
-    call the model's `optimizer`'s `minimize` method (please note that the `optimizer`
-    attribute must implement the `kormos.optimizers.BatchOptimizer` interface).
-    The `optimizer` should implement a gradient-based optimization algorithm that uses
-    the *entire* set of training data to make parameter updates.
+        If the `optimizer` argument is specified as a valid `kormos.optimizers.BatchOptimizer`
+        (or a valid string identifier to create one using `kormos.optimizers.get()`), then
+        the model will be configured to map calls to `fit` to the method `fit_batch`.
 
-    This is different than the standard `keras model training procedure <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training.py>`_
-    in which mini-batches (sample subsets) of the training dataset are created
-    and the optimizer makes updates to the model parameters with a stochastic
-    algorithm using only that subset.
+        Keyword Args:
+          optimizer: A `keras.optimizer.Optimizer` or string identifier, or a `kormos.optimizer.BatchOptimizer` or string identifier
+          **kwargs: all other `kwargs` as passed to `keras.Model.compile <https://keras.io/api/models/model_training_apis/#compile-method>`_
+        """
+        optimizer_orig = kwargs.pop("optimizer", "rmsprop")
+        use_batch_fit = False
+        try:
+            optimizer = keras.optimizers.get(optimizer_orig)
+            logger.warning(f"BatchOptimizedModel compiled with optimizer={optimizer}.")
+        except ValueError:
+            # A BatchOptimizer or its string identifier will raise a ValueError,
+            # in which case we know to fit this model using .fit_batch()
+            optimizer = "rmsprop"  # Set a valid default to call .compile() as a dummy
+            use_batch_fit = True
 
-    The arguments to this method have the same meaning as for the `keras.models.Model.fit <https://keras.io/api/models/model_training_apis/#fit-method>`_ method; please see the documentation there except
-    for the arguments noted below.
+        super().compile(optimizer=optimizer, **kwargs)
+        # If we are fitting with a deterministic batch algorithm, reset
+        # the optimizer to the desired one after compilation
+        if use_batch_fit:
+            self.optimizer = kormos.optimizers.get(optimizer_orig)
+            self.fit = self.fit_batch
 
-    Args:
-      batch_size (int): the number of training examples to process in a single "mini-batch" if the 
-        training dataset provided to `compile` must be converted to a `tensorflow.data.Dataset`.
-        If unspecified and the training data provided must be converted to a `tensorflow.data.Dataset`,
-        the value in this model's `optimizer` (of type `BatchOptimizer`) will be used.
-        Please note the choice of `batch_size` here is different than in
-        stochastic optimization in which the optimizer typically performs best with
-        small mini-batches on the order of ``2^4`` or ``2^5``. The `batch_size` here
-        should be determined based on the available machine memory, and good values
-        will be on the order of ``2^12`` or larger, depending on the memory requirements
-        for the evaluation of the model (memory limitations are more likely to be
-        encountered if second order algorithsm like the Newton-CG method are used).
-      pretrain_fn (callable): univariate function that accepts the model as its argument
-        and performs an arbitrary operation on it. Or, a list of such functions if the
-        model's `optimizer` accepts it. The `pretrain_fn` will be applied prior to
-        the start of the optimization routine.
-    Keyword Args:
-      **kwargs: keyword arguments to be passed to this model's `optimizer.minimize(**kwargs)` method
-    Returns:
-        A `History` object. Its `History.history` attribute is
-        a record of training loss values and metrics values
-        at successive epochs, as well as validation loss values
-        and validation metrics values (if applicable).
-    Raises:
-        RuntimeError: 1. If the model was never compiled or,
-        2. If `model.fit` is  wrapped in `tf.function`.
-        ValueError: In case of mismatch between the provided input data
-            and what the model expects or when the input data is empty.
-    """
-    self._assert_compile_was_called()
-    self._check_call_args("fit")
-    if batch_size is not None:
-      logger.warning(
-        f"batch_size={batch_size} was provided; this will override the setting:"
-        f"BatchOptimizedModel.optimizer.batch_size={BatchOptimizedModel.optimizer.batch_size}."
-      )
-
-    if verbose == 'auto':
-      if self.distribute_strategy._should_use_with_coordinator:  # pylint: disable=protected-access
-        verbose = 2  # Default to epoch-level logging for PSStrategy.
-      else:
-        verbose = 1  # Default to batch-level logging otherwise.
-
-    if validation_split:
-      # Create the validation data using the training data. Only supported for
-      # `Tensor` and `NumPy` input.
-      (x, y, sample_weight), validation_data = (
-          data_adapter.train_validation_split(
-              (x, y, sample_weight), validation_split=validation_split))
-
-    if validation_data:
-      val_x, val_y, val_sample_weight = (
-          data_adapter.unpack_x_y_sample_weight(validation_data))
-
-    if self.distribute_strategy._should_use_with_coordinator:  # pylint: disable=protected-access
-      self._cluster_coordinator = cluster_coordinator.ClusterCoordinator(
-          self.distribute_strategy)
-
-    # Container that configures and calls `tf.keras.Callback`s.
-    if not isinstance(callbacks, callbacks_module.CallbackList):
-      callbacks = callbacks_module.CallbackList(
-        callbacks,
-        add_history=True,
-        add_progbar=(verbose != 0),
-        model=self,
-        verbose=verbose,
-        epochs=epochs,
-        steps=1,
-      )
-
-    with self.distribute_strategy.scope(), \
-       training_utils.RespectCompiledTrainableState(self):
-
-      # Creates a `tf.data.Dataset` and handles batch and epoch iteration.
-      data_handler = data_adapter.get_data_handler(
-        x=x,
-        y=y,
-        sample_weight=sample_weight,
-        batch_size=batch_size or self.optimizer.batch_size,
+    @traceback_utils.filter_traceback
+    def fit_batch(
+        self,
+        x=None,
+        y=None,
+        batch_size=None,
+        epochs=20,
+        verbose="auto",
+        callbacks=None,
+        validation_split=0.0,
+        validation_data=None,
+        shuffle=False,
+        class_weight=None,
+        sample_weight=None,
+        initial_epoch=0,
         steps_per_epoch=None,
-        initial_epoch=initial_epoch,
-        epochs=1,
-        shuffle=shuffle,
-        class_weight=class_weight,
-        max_queue_size=max_queue_size,
-        workers=workers,
-        use_multiprocessing=use_multiprocessing,
-        model=self,
-        steps_per_execution=self._steps_per_execution
-      )
+        validation_steps=None,
+        validation_batch_size=None,
+        validation_freq=1,
+        max_queue_size=10,
+        workers=1,
+        use_multiprocessing=False,
+        pretrain_fn=None,
+        **kwargs,
+    ):
+        """
+        Train the model using a batch optimization algorithm for up to the maximum number
+        of iterations (`epochs`), and return the optimization history object.
 
-      def _callback(x):
-        self._epoch += 1
-        epoch = self._epoch
-        logs = {
-          'loss': self.optimizer.func(x),
-          'grad': np.linalg.norm(self.optimizer.grad(x)),
-          'fg_evals': self.optimizer.fg_evals,
-          'hessp_evals': self.optimizer.hessp_evals,
-        }
+        This method will prepare the training dataset and execution context, and then
+        call the model's `optimizer`'s `minimize` method (please note that the `optimizer`
+        attribute must implement the `kormos.optimizers.BatchOptimizer` interface).
+        The `optimizer` should implement a gradient-based optimization algorithm that uses
+        the *entire* set of training data to make parameter updates.
 
-        # Compute metrics on the validation set
-        if validation_data is not None and self._should_eval(epoch, validation_freq):
-          # Create data_handler for evaluation and cache it.
-          if getattr(self, '_eval_data_handler', None) is None:
-            self._eval_data_handler = data_adapter.get_data_handler(
-              x=val_x,
-              y=val_y,
-              sample_weight=val_sample_weight,
-              batch_size=validation_batch_size or batch_size or self.optimizer.batch_size,
-              steps_per_epoch=validation_steps,
-              initial_epoch=0,
-              epochs=1,
-              max_queue_size=max_queue_size,
-              workers=workers,
-              use_multiprocessing=use_multiprocessing,
-              model=self,
-              steps_per_execution=self._steps_per_execution,
+        This is different than the standard `keras model training procedure <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training.py>`_
+        in which mini-batches (sample subsets) of the training dataset are created
+        and the optimizer makes updates to the model parameters with a stochastic
+        algorithm using only that subset.
+
+        The arguments to this method have the same meaning as for the `keras.models.Model.fit <https://keras.io/api/models/model_training_apis/#fit-method>`_ method; please see the documentation there except
+        for the arguments noted below.
+
+        Args:
+          batch_size (int): the number of training examples to process in a single "mini-batch" if the
+            training dataset provided to `compile` must be converted to a `tensorflow.data.Dataset`.
+            If unspecified and the training data provided must be converted to a `tensorflow.data.Dataset`,
+            the value in this model's `optimizer` (of type `BatchOptimizer`) will be used.
+            Please note the choice of `batch_size` here is different than in
+            stochastic optimization in which the optimizer typically performs best with
+            small mini-batches on the order of ``2^4`` or ``2^5``. The `batch_size` here
+            should be determined based on the available machine memory, and good values
+            will be on the order of ``2^12`` or larger, depending on the memory requirements
+            for the evaluation of the model (memory limitations are more likely to be
+            encountered if second order algorithsm like the Newton-CG method are used).
+          pretrain_fn (callable): univariate function that accepts the model as its argument
+            and performs an arbitrary operation on it. Or, a list of such functions if the
+            model's `optimizer` accepts it. The `pretrain_fn` will be applied prior to
+            the start of the optimization routine.
+        Keyword Args:
+          **kwargs: keyword arguments to be passed to this model's `optimizer.minimize(**kwargs)` method
+        Returns:
+            A `History` object. Its `History.history` attribute is
+            a record of training loss values and metrics values
+            at successive epochs, as well as validation loss values
+            and validation metrics values (if applicable).
+        Raises:
+            RuntimeError: 1. If the model was never compiled or,
+            2. If `model.fit` is  wrapped in `tf.function`.
+            ValueError: In case of mismatch between the provided input data
+                and what the model expects or when the input data is empty.
+        """
+        self._assert_compile_was_called()
+        self._check_call_args("fit")
+        if batch_size is not None:
+            logger.warning(
+                f"batch_size={batch_size} was provided; this will override the setting:"
+                f"BatchOptimizedModel.optimizer.batch_size={BatchOptimizedModel.optimizer.batch_size}."
             )
-          val_logs = self.evaluate(
-            x=val_x,
-            y=val_y,
-            sample_weight=val_sample_weight,
-            batch_size=validation_batch_size or batch_size or self.optimizer.batch_size,
-            steps=validation_steps,
-            callbacks=callbacks,
-            max_queue_size=max_queue_size,
-            workers=workers,
-            use_multiprocessing=use_multiprocessing,
-            return_dict=True,
-            _use_cached_eval_dataset=True,
-          )
-          val_logs = {'val_' + name: val for name, val in val_logs.items()}
-          logs.update(val_logs)
 
-        callbacks.on_train_batch_end(epoch, logs)
-        callbacks.on_epoch_end(epoch, logs)
+        if verbose == "auto":
+            if (
+                self.distribute_strategy._should_use_with_coordinator
+            ):  # pylint: disable=protected-access
+                verbose = 2  # Default to epoch-level logging for PSStrategy.
+            else:
+                verbose = 1  # Default to batch-level logging otherwise.
 
-        callbacks.on_epoch_begin(epoch + 1)
-        callbacks.on_train_batch_begin(epoch + 1)
+        if validation_split:
+            # Create the validation data using the training data. Only supported for
+            # `Tensor` and `NumPy` input.
+            (
+                x,
+                y,
+                sample_weight,
+            ), validation_data = data_adapter.train_validation_split(
+                (x, y, sample_weight), validation_split=validation_split
+            )
 
-    logs = None
-    self._epoch = 0
-    callbacks.on_train_begin()
-    callbacks.on_epoch_begin(self._epoch)
-    callbacks.on_train_batch_begin(self._epoch)
+        if validation_data:
+            val_x, val_y, val_sample_weight = data_adapter.unpack_x_y_sample_weight(
+                validation_data
+            )
 
-    self.optimizer.build(model=self, Xyw=data_handler._dataset)
-    result = self.optimizer.minimize(
-      epochs=epochs,
-      callback=_callback,
-      pretrain_fn=pretrain_fn,
-      **kwargs
-    )
-    self.optimizer.set_weights(result)
-    callbacks.on_train_end(logs=logs)
-    return self.history
+        if (
+            self.distribute_strategy._should_use_with_coordinator
+        ):  # pylint: disable=protected-access
+            self._cluster_coordinator = cluster_coordinator.ClusterCoordinator(
+                self.distribute_strategy
+            )
+
+        # Container that configures and calls `tf.keras.Callback`s.
+        if not isinstance(callbacks, callbacks_module.CallbackList):
+            callbacks = callbacks_module.CallbackList(
+                callbacks,
+                add_history=True,
+                add_progbar=(verbose != 0),
+                model=self,
+                verbose=verbose,
+                epochs=epochs,
+                steps=1,
+            )
+
+        with self.distribute_strategy.scope(), training_utils.RespectCompiledTrainableState(
+            self
+        ):
+
+            # Creates a `tf.data.Dataset` and handles batch and epoch iteration.
+            data_handler = data_adapter.get_data_handler(
+                x=x,
+                y=y,
+                sample_weight=sample_weight,
+                batch_size=batch_size or self.optimizer.batch_size,
+                steps_per_epoch=None,
+                initial_epoch=initial_epoch,
+                epochs=1,
+                shuffle=shuffle,
+                class_weight=class_weight,
+                max_queue_size=max_queue_size,
+                workers=workers,
+                use_multiprocessing=use_multiprocessing,
+                model=self,
+                steps_per_execution=self._steps_per_execution,
+            )
+
+            def _callback(x):
+                self._epoch += 1
+                epoch = self._epoch
+                logs = {
+                    "loss": self.optimizer.func(x),
+                    "grad": np.linalg.norm(self.optimizer.grad(x)),
+                    "fg_evals": self.optimizer.fg_evals,
+                    "hessp_evals": self.optimizer.hessp_evals,
+                }
+
+                # Compute metrics on the validation set
+                if validation_data is not None and self._should_eval(
+                    epoch, validation_freq
+                ):
+                    # Create data_handler for evaluation and cache it.
+                    if getattr(self, "_eval_data_handler", None) is None:
+                        self._eval_data_handler = data_adapter.get_data_handler(
+                            x=val_x,
+                            y=val_y,
+                            sample_weight=val_sample_weight,
+                            batch_size=validation_batch_size
+                            or batch_size
+                            or self.optimizer.batch_size,
+                            steps_per_epoch=validation_steps,
+                            initial_epoch=0,
+                            epochs=1,
+                            max_queue_size=max_queue_size,
+                            workers=workers,
+                            use_multiprocessing=use_multiprocessing,
+                            model=self,
+                            steps_per_execution=self._steps_per_execution,
+                        )
+                    val_logs = self.evaluate(
+                        x=val_x,
+                        y=val_y,
+                        sample_weight=val_sample_weight,
+                        batch_size=validation_batch_size
+                        or batch_size
+                        or self.optimizer.batch_size,
+                        steps=validation_steps,
+                        callbacks=callbacks,
+                        max_queue_size=max_queue_size,
+                        workers=workers,
+                        use_multiprocessing=use_multiprocessing,
+                        return_dict=True,
+                        _use_cached_eval_dataset=True,
+                    )
+                    val_logs = {"val_" + name: val for name, val in val_logs.items()}
+                    logs.update(val_logs)
+
+                callbacks.on_train_batch_end(epoch, logs)
+                callbacks.on_epoch_end(epoch, logs)
+
+                callbacks.on_epoch_begin(epoch + 1)
+                callbacks.on_train_batch_begin(epoch + 1)
+
+        logs = None
+        self._epoch = 0
+        callbacks.on_train_begin()
+        callbacks.on_epoch_begin(self._epoch)
+        callbacks.on_train_batch_begin(self._epoch)
+
+        self.optimizer.build(model=self, Xyw=data_handler._dataset)
+        result = self.optimizer.minimize(
+            epochs=epochs, callback=_callback, pretrain_fn=pretrain_fn, **kwargs
+        )
+        self.optimizer.set_weights(result)
+        callbacks.on_train_end(logs=logs)
+        return self.history
 
 
 class BatchOptimizedSequentialModel(keras.models.Sequential, BatchOptimizedModel):
-  pass
+    pass

--- a/kormos/optimizers.py
+++ b/kormos/optimizers.py
@@ -39,717 +39,801 @@ from kormos.utils.cache import OptimizationStateCache
 
 logger = logging.getLogger(__name__)
 
-OPTIMIZER_IDENTIFIERS = set(['scipy'] + [
-  method.lower() for method in MINIMIZE_METHODS
-] + [
-  method.upper() for method in MINIMIZE_METHODS
-])
+OPTIMIZER_IDENTIFIERS = set(
+    ["scipy"]
+    + [method.lower() for method in MINIMIZE_METHODS]
+    + [method.upper() for method in MINIMIZE_METHODS]
+)
 
 
 class BatchOptimizer(object):
-  """
-  An optimizer class providing function callables for minimization by batch optimization algorithms.
-
-  Codes implementing batch minimization routines, such `scipy.optimize.minimize`,
-  typically have a call signature like the following:
-
-  .. code-block:: python
-
-    minimize(
-      fun,        # callable, the objective function f(x) to minimize 
-      ...
-      jac=None,   # callable, the jacobian of f(x)
-      hessp=None, # callable implementing a hessian/vector product for the hessian of f(x)
-      ...
-    )
-
-  The `BatchOptimizer` factory class provides methods with the appropriate signature for the above callables:
-  
-  - `fun`, in the method `func(x)` or `func_and_grad(x)`
-  - `jac`, in the method `grad(x)` or `func_and_grad(x)`
-  - `hessp`, in the method `hessp(x, vector)`
-
-  This class implements the callables above for a provided `keras.Model` and training dataset,
-  in which the execution paradigm is for *full batch* gradient-based optimization, in which
-  every sample in a provided dataset is used to compute the loss function and gradient values.
-
-  The `BatchOptimizer` class implements the function and gradient by evaluating them over
-  mini-batches of data and accumulating the result of each minibatch such that the computation
-  is robust even when the training dataset is large or the model requires lots of RAM or
-  GPU memory. To ensure the correct summation, the model's `loss` function attribute
-  must have the `reduction=keras.losses.Reduction.SUM` explicitly set (after which
-  the total sum will be averaged).
-
-  Child classes extending this base class must implement `minimize`, which is the method
-  that implements a gradient-based (or Hessian-based) optimization algorithm.
-  """
-  
-  def __init__(self,
-    name="batchoptimizer", 
-    batch_size=2**10,
-    max_cache_entries=10,
-    dtype=tf.float64,
-  ):
     """
-    Construct a `BatchOptimizer` object, but do not build it.
-    Please note that the `build` method must be called before parameter
-    optimization may be performed on a model.
+    An optimizer class providing function callables for minimization by batch optimization algorithms.
 
-    The provided `batch_size` here will only be used if `build()` is called with
-    training dataset that is not already adapated into a `tensorflow.data.Dataset`.
-    In this case, the choice of `batch_size` here is different than in stochastic
-    optimization in which the optimizer typically performs best with small
-    mini-batches on the order of ``2^4`` or ``2^5``. The `batch_size` here should
-    be determined based on the available machine memory, and good values will be on
-    the order of ``2^12`` or larger, depending on the memory requirements for the
-    evaluation of the model (memory limitations are more likely to be encountered
-    if second order algorithsm like the Newton-CG method are used).
+    Codes implementing batch minimization routines, such `scipy.optimize.minimize`,
+    typically have a call signature like the following:
 
-    The `dtype` of a model's backing tensors when converting to an
-    `numpy.ndarray` may be explicitly specified. In general, `tensorflow.float64`
-    will make the optimization routine more numerically robust for loss functions
-    with flat regions, and as such double precision is recommended for the
-    tensorflow model itself. While single precision (`tensorflow.float32`) is often
-    used in deep learning applications, numerical minimization routines that use
-    line searches may require double precision (`tensorflow.float64`) for Wolfe
-    convergence criteria (sufficient decrease) to be numerically resolvable.  In
-    addition, since `scipy.optimize.minimize` routines wrap Fortran codes that
-    expect double precision, it is generally necessary to use double precision for
-    robust with `scipy` Altering this will [probably] only work on bespoke
-    locally-compiled `scipy` distributions.  and the `kormos` package isn't tested
-    against anything other than double precision.  In reality this really shouldn't
-    even be exposed as an argument---just walk away and let's forget the whole
-    thing.
+    .. code-block:: python
 
-    Args:
-      batch_size (int): the number of training examples to process in a single "mini-batch" if the 
-        training dataset provided to `build()` must be converted to a `tensorflow.data.Dataset`
-      max_cache_entries (int): the number of previous `loss/gradient/hessp` values to cache during training.
-      dtype: the `tensorflow dtype` to use for weight matrices, defaults to `tf.float64`.
-    """
-    self.name = name
-    self.batch_size = batch_size
-    self.dtype = dtype
-
-    self._built = False
-    self.cache = OptimizationStateCache(max_entries=max_cache_entries)
-    self.k = 0
-    self.fg_evals = 0
-    self.hessp_evals = 0
-    self.reweight_batches = False
-    self.results = []
-
-  def build(self, model, Xyw):
-    """
-    Dynamically build this `BatchOptimizer` object to prepare for
-    a minimization routine for parameter fitting.
-
-    The build process consists of 2 steps:
-
-    - Store the size metadata about this object's `model`'s
-      `trainable_weights` such that we may convert between the stacked
-      `numpy.ndarray` vector of parameters and the `model`'s list of multidimensional
-      tensors.
-    - Create the tensorflow `function`-wrapped callables to evaluate the loss
-      function, the gradient, and the Hessian/vector product. These callables
-      are built dynamically on each call to `build`, such that the model
-      metadata may be used to create them. Tensorflow's autograph tracing should occurr
-      only once on these callables.
-
-    This method has been partly adapted from Pi-Yueh Chuang's MIT-licensed
-    `code <https://gist.github.com/piyueh/712ec7d4540489aad2dcfb80f9a54993>`_,
-    and this file retains the original 2019 copyright notice above.
-
-    Aggs:
-      model (keras.Model): the model to be optimized
-      Xyw (tensorflow.data.Dataset): the training dataset for optimization. If a type other
-        than `Dataset` is provided, this method will attempt to create one using the
-        `BatchOptimizer`'s `batch_size` attribute. Providing a `Dataset` is recommended.
-    Raises:
-      ValueError: if the `model.loss.reduction` is not `kerass.losses.reduction.Reduction.SUM`
-    """
-
-    def _build_weight_indices():
-      # This code has been modified from a program with the original copyright notice:
-      #
-      # Copyright © 2019 Pi-Yueh Chuang <pychuang@gwu.edu>
-      # Distributed under terms of the MIT license.
-
-      shapes = tf.shape_n(model.trainable_weights)
-      n_tensors = len(shapes)
-
-      idx_end = 0
-      idx = [] # stitch indices
-      part = [] # partition indices
-
-      for part_num, shape in enumerate(shapes):
-        num_elements = np.product(shape)
-        idx_start = idx_end
-        idx_end = idx_start + num_elements
-        idx.append(tf.reshape(tf.range(idx_start, idx_end, dtype=tf.int32), shape))
-        part.extend(num_elements * [part_num])
-
-      self.num_model_variables = idx_end
-      self.part = tf.constant(part)
-      self.idx = idx
-      self.shapes = shapes
-      self.n_tensors = n_tensors
-
-    if not issubclass(type(model.loss), keras.losses.Loss):
-      raise ValueError(
-        f"Provided model.loss={model.loss} is type: {type(model.loss)}, but a keras.losses.Loss is required"
-      )
-    if not issubclass(type(Xyw), tf.data.Dataset):
-      logger.warning(
-        f"Provided type of Xyw is '{type(Xyw)}; attempting to create "
-        f"a data adapter with batch_size={self.batch_size}. "
-        f"It is recommended you provide a tensorflow.data.Dataset directly."
-      )
-      if type(Xyw) is tuple:
-        x, y, w = data_adapter.unpack_x_y_sample_weight(Xyw)
-        # The DataHandler here will distribute the data with <strategy>.experimental_distribute_dataset()
-        Xyw = data_adapter.get_data_handler(
-          x=x, y=y, sample_weight=w, model=model, batch_size=self.batch_size
-        )._dataset
-      else:
-        Xyw = data_adapter.get_data_handler(x=Xyw, model=model, batch_size=self.batch_size)._dataset
-      logger.warning(f"Converted input data to {type(Xyw)}")
-
-    self.model = model
-    self.strategy = getattr(model, 'strategy', tf.distribute.get_strategy())
-    self.reweight_batches = (model.loss.reduction != keras.losses.Reduction.SUM)
-    self.Xyw = Xyw
-    _build_weight_indices()
-
-    if model.run_eagerly:
-      self._fg = self._build_fg()
-      self._reg_fg = self._build_reg_fg()
-      self._hessp = self._build_hessp()
-      self._reg_hessp = self._build_reg_hessp()
-    else:
-      self._fg = tf.function(self._build_fg(), experimental_relax_shapes=True)
-      self._reg_fg = tf.function(self._build_reg_fg(), experimental_relax_shapes=True)
-      self._hessp = tf.function(self._build_hessp(), experimental_relax_shapes=True)
-      self._reg_hessp = tf.function(self._build_reg_hessp(), experimental_relax_shapes=True)
-    self._built = True
-    return self
-
-  def _numpy_to_tensors(self, x):
-    """
-    Convert a (vector) `numpy.ndarray` of parameters to a list of tensors.
-
-    Args:
-      x (numpy.ndarray): vector of parameters used by `scipy.optimize.minimize`
-
-    Returns:
-      A list of tensors matching the shapes of this object's `model.trainable_weights`
-    """
-    assert self._built
-    parts = tf.dynamic_partition(x, self.part, self.n_tensors)
-    return [tf.reshape(part, self.shapes[k]) for (k, part) in enumerate(parts)]
-
-  def _tensors_to_numpy(self, weights):
-    """
-    Convert a list of tensors to a (vector) `numpy.ndarray` of parameters.
-
-    Args:
-      weights: list of tensors matching the shapes of this object's `model.trainable_weights`
-
-    Returns:
-      numpy.ndarray: vector of parameters used by `scipy.optimize.minimize`
-    """
-    assert self._built
-    return tf.cast(tf.dynamic_stitch(self.idx, weights), dtype=self.dtype).numpy()
-
-  def get_weights(self):
-    """
-    Retrieve the `model` weights as a `numpy.ndarray` vector.
-
-    Returns:
-      numpy.ndarray: vector of parameters used by `scipy.optimize.minimize`
-    """
-    assert self._built
-    w = self._tensors_to_numpy(self.model.trainable_variables)
-    return w
-
-  def set_weights(self, x):
-    """
-    Set a `keras` model's `model.trainable_weights` (by default, use this object's `model`).
-
-    Args:
-      x: a `numpy.ndarray` (or similar iterable) parameter vector
-    """
-    assert self._built
-    model = self.model
-    params = tf.dynamic_partition(
-      tf.convert_to_tensor(x),
-      self.part,
-      self.n_tensors,
-    )
-    for i, (shape, param) in enumerate(zip(self.shapes, params)):
-      model.trainable_variables[i].assign(
-        tf.cast(tf.reshape(param, shape), model.trainable_variables[i].dtype)
+      minimize(
+        fun,        # callable, the objective function f(x) to minimize
+        ...
+        jac=None,   # callable, the jacobian of f(x)
+        hessp=None, # callable implementing a hessian/vector product for the hessian of f(x)
+        ...
       )
 
-  def _build_reg_fg(self):
+    The `BatchOptimizer` factory class provides methods with the appropriate signature for the above callables:
+
+    - `fun`, in the method `func(x)` or `func_and_grad(x)`
+    - `jac`, in the method `grad(x)` or `func_and_grad(x)`
+    - `hessp`, in the method `hessp(x, vector)`
+
+    This class implements the callables above for a provided `keras.Model` and training dataset,
+    in which the execution paradigm is for *full batch* gradient-based optimization, in which
+    every sample in a provided dataset is used to compute the loss function and gradient values.
+
+    The `BatchOptimizer` class implements the function and gradient by evaluating them over
+    mini-batches of data and accumulating the result of each minibatch such that the computation
+    is robust even when the training dataset is large or the model requires lots of RAM or
+    GPU memory. To ensure the correct summation, the model's `loss` function attribute
+    must have the `reduction=keras.losses.Reduction.SUM` explicitly set (after which
+    the total sum will be averaged).
+
+    Child classes extending this base class must implement `minimize`, which is the method
+    that implements a gradient-based (or Hessian-based) optimization algorithm.
     """
-    Create a callable to evaluate the regularization component of the loss function
-    which may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
-    Before the callable may be executed, the model's weights must be set with
-    this object's `set_weights()` method.
-    
-    Returns:
-      callable (with no arguments)
-    """
-    (model, strategy) = (self.model, self.strategy)
-    def _fn():
-      def _distrib_fn():
-        z = tf.convert_to_tensor([0.0])
-        with tf.GradientTape() as tape:
-          reg_loss = math_ops.add_n(model.losses)
-        reg_grad = [
-          g if g is not None else (0 * w)
-          for (g, w) in zip(tape.gradient(reg_loss, model.trainable_variables), model.trainable_variables)
-        ]
-        reg_grad = tf.cast(tf.dynamic_stitch(self.idx, reg_grad), dtype=self.dtype)
-        return reg_loss, reg_grad
-      result = strategy.run(_distrib_fn, args=())
-      return training.reduce_per_replica(result, strategy, 'first')
-    return _fn
 
-  def _build_fg(self):
-    """
-    Create a callable to evaluate the sample loss component of the loss function
-    which may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
-    Before the callable may be executed, the model's weights must be set with
-    this object's `set_weights()` method.
+    def __init__(
+        self,
+        name="batchoptimizer",
+        batch_size=2**10,
+        max_cache_entries=10,
+        dtype=tf.float64,
+    ):
+        """
+        Construct a `BatchOptimizer` object, but do not build it.
+        Please note that the `build` method must be called before parameter
+        optimization may be performed on a model.
 
-    Please note that the function `model.loss()` is evaluated rather than the
-    `model.compiled_loss()`. Since we accumulate each batch's loss over the entire
-    training set, there is no need to perform the additional loss metric
-    computations that happen in the `LossesContainer`.
+        The provided `batch_size` here will only be used if `build()` is called with
+        training dataset that is not already adapated into a `tensorflow.data.Dataset`.
+        In this case, the choice of `batch_size` here is different than in stochastic
+        optimization in which the optimizer typically performs best with small
+        mini-batches on the order of ``2^4`` or ``2^5``. The `batch_size` here should
+        be determined based on the available machine memory, and good values will be on
+        the order of ``2^12`` or larger, depending on the memory requirements for the
+        evaluation of the model (memory limitations are more likely to be encountered
+        if second order algorithsm like the Newton-CG method are used).
 
-    Returns:
-      callable (with no arguments)
-    """
-    (model, strategy) = (self.model, self.strategy)
+        The `dtype` of a model's backing tensors when converting to an
+        `numpy.ndarray` may be explicitly specified. In general, `tensorflow.float64`
+        will make the optimization routine more numerically robust for loss functions
+        with flat regions, and as such double precision is recommended for the
+        tensorflow model itself. While single precision (`tensorflow.float32`) is often
+        used in deep learning applications, numerical minimization routines that use
+        line searches may require double precision (`tensorflow.float64`) for Wolfe
+        convergence criteria (sufficient decrease) to be numerically resolvable.  In
+        addition, since `scipy.optimize.minimize` routines wrap Fortran codes that
+        expect double precision, it is generally necessary to use double precision for
+        robust with `scipy` Altering this will [probably] only work on bespoke
+        locally-compiled `scipy` distributions.  and the `kormos` package isn't tested
+        against anything other than double precision.  In reality this really shouldn't
+        even be exposed as an argument---just walk away and let's forget the whole
+        thing.
 
-    def _per_replica_fg(data):
-      data = data_adapter.expand_1d(data)
-      x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
-      num_samples = len(x)
+        Args:
+          batch_size (int): the number of training examples to process in a single "mini-batch" if the
+            training dataset provided to `build()` must be converted to a `tensorflow.data.Dataset`
+          max_cache_entries (int): the number of previous `loss/gradient/hessp` values to cache during training.
+          dtype: the `tensorflow dtype` to use for weight matrices, defaults to `tf.float64`.
+        """
+        self.name = name
+        self.batch_size = batch_size
+        self.dtype = dtype
 
-      with tf.GradientTape() as tape:
-        y_pred = model(x, training=True)
-        batch_loss = model.loss(y, y_pred, sample_weight=sample_weight)
+        self._built = False
+        self.cache = OptimizationStateCache(max_entries=max_cache_entries)
+        self.k = 0
+        self.fg_evals = 0
+        self.hessp_evals = 0
+        self.reweight_batches = False
+        self.results = []
 
-      # calculate gradients and convert to 1D tf.Tensor
-      batch_grad = tape.gradient(batch_loss, model.trainable_variables)
-      batch_grad = tf.cast(tf.dynamic_stitch(self.idx, batch_grad), dtype=self.dtype)
+    def build(self, model, Xyw):
+        """
+        Dynamically build this `BatchOptimizer` object to prepare for
+        a minimization routine for parameter fitting.
 
-      coeff = tf.cast(num_samples if self.reweight_batches else 1.0, dtype=self.dtype)
-      return (coeff * tf.cast(batch_loss, self.dtype), coeff * batch_grad, num_samples)
+        The build process consists of 2 steps:
 
-    def _fn():
-      n = tf.constant(0, dtype=tf.int32)
-      loss = tf.constant(0.0, dtype=self.dtype)
-      grad = tf.zeros(shape=(self.num_model_variables,), dtype=self.dtype)
+        - Store the size metadata about this object's `model`'s
+          `trainable_weights` such that we may convert between the stacked
+          `numpy.ndarray` vector of parameters and the `model`'s list of multidimensional
+          tensors.
+        - Create the tensorflow `function`-wrapped callables to evaluate the loss
+          function, the gradient, and the Hessian/vector product. These callables
+          are built dynamically on each call to `build`, such that the model
+          metadata may be used to create them. Tensorflow's autograph tracing should occurr
+          only once on these callables.
 
-      for data in iter(self.Xyw):
-        per_replica_loss, per_replica_grad, per_replica_n = strategy.run(_per_replica_fg, args=(data,))
-        loss += strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_loss, axis=None) 
-        grad += strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_grad, axis=None) 
-        n += strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_n, axis=None) 
+        This method has been partly adapted from Pi-Yueh Chuang's MIT-licensed
+        `code <https://gist.github.com/piyueh/712ec7d4540489aad2dcfb80f9a54993>`_,
+        and this file retains the original 2019 copyright notice above.
 
-      coeff = (1.0 / tf.cast(n, dtype=self.dtype)) if self.reweight_batches else 1.0
-      return (coeff * loss), (coeff * grad) 
+        Aggs:
+          model (keras.Model): the model to be optimized
+          Xyw (tensorflow.data.Dataset): the training dataset for optimization. If a type other
+            than `Dataset` is provided, this method will attempt to create one using the
+            `BatchOptimizer`'s `batch_size` attribute. Providing a `Dataset` is recommended.
+        Raises:
+          ValueError: if the `model.loss.reduction` is not `kerass.losses.reduction.Reduction.SUM`
+        """
 
-    return _fn
+        def _build_weight_indices():
+            # This code has been modified from a program with the original copyright notice:
+            #
+            # Copyright © 2019 Pi-Yueh Chuang <pychuang@gwu.edu>
+            # Distributed under terms of the MIT license.
 
-  def _build_reg_hessp(self):
-    """
-    Create a callable to evaluate the regularization component of the HVP, which
-    may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
-    Before the callable may be executed, the model's weights must be set with
-    this object's `set_weights()` method.
+            shapes = tf.shape_n(model.trainable_weights)
+            n_tensors = len(shapes)
 
-    Returns:
-      callable taking 1 argument; a `tf.Tensor` representing the vector in the HVP 
-    """
-    (model, strategy) = (self.model, self.strategy)
-    def _fn(vec):
-      def _distrib_fn(vec):
-        z = tf.zeros(shape=(1,), dtype=self.dtype)
-        with tf.GradientTape() as outer_tape:
-          with tf.GradientTape() as inner_tape:
-            reg_loss = math_ops.add_n(model.losses)
-          reg_grad_slices = [
-            g if g is not None else (0.0 * w)
-            for (g, w) in zip(inner_tape.gradient(reg_loss, model.trainable_variables), model.trainable_variables)
-          ]
-          reg_grads = [tf.cast(tf.convert_to_tensor(g), dtype=self.dtype) for g in reg_grad_slices]
+            idx_end = 0
+            idx = []  # stitch indices
+            part = []  # partition indices
 
-        reg_hvp = outer_tape.gradient(reg_grads, model.trainable_variables, output_gradients=vec)
-        reg_hvp = tf.dynamic_stitch(self.idx, reg_hvp)
-        return reg_hvp
-      result = strategy.run(_distrib_fn, args=(vec,))
-      return training.reduce_per_replica(result, strategy, 'first')
-    return _fn
+            for part_num, shape in enumerate(shapes):
+                num_elements = np.product(shape)
+                idx_start = idx_end
+                idx_end = idx_start + num_elements
+                idx.append(
+                    tf.reshape(tf.range(idx_start, idx_end, dtype=tf.int32), shape)
+                )
+                part.extend(num_elements * [part_num])
 
-  def _build_hessp(self):
-    """
-    Create a callable to evaluate the sample loss component of the HVP, which
-    may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
-    Before the callable may be executed, the model's weights must be set with
-    this object's `set_weights()` method.
+            self.num_model_variables = idx_end
+            self.part = tf.constant(part)
+            self.idx = idx
+            self.shapes = shapes
+            self.n_tensors = n_tensors
 
-    Please note that the function `model.loss()` is evaluated rather than the
-    `model.compiled_loss()`. Since we accumulate each batch's loss over the entire
-    training set, there is no need to perform the additional loss metric
-    computations that happen in the `LossesContainer`.
-    
-    Returns:
-      callable taking 1 argument; a `tf.Tensor` representing the vector in the HVP 
-    """
-    (model, strategy) = (self.model, self.strategy)
+        if not issubclass(type(model.loss), keras.losses.Loss):
+            raise ValueError(
+                f"Provided model.loss={model.loss} is type: {type(model.loss)}, but a keras.losses.Loss is required"
+            )
+        if not issubclass(type(Xyw), tf.data.Dataset):
+            logger.warning(
+                f"Provided type of Xyw is '{type(Xyw)}; attempting to create "
+                f"a data adapter with batch_size={self.batch_size}. "
+                f"It is recommended you provide a tensorflow.data.Dataset directly."
+            )
+            if type(Xyw) is tuple:
+                x, y, w = data_adapter.unpack_x_y_sample_weight(Xyw)
+                # The DataHandler here will distribute the data with <strategy>.experimental_distribute_dataset()
+                Xyw = data_adapter.get_data_handler(
+                    x=x, y=y, sample_weight=w, model=model, batch_size=self.batch_size
+                )._dataset
+            else:
+                Xyw = data_adapter.get_data_handler(
+                    x=Xyw, model=model, batch_size=self.batch_size
+                )._dataset
+            logger.warning(f"Converted input data to {type(Xyw)}")
 
-    def _per_replica_hessp(data, vec):
-      data = data_adapter.expand_1d(data)
-      x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
-      # num_samples = tf.convert_to_tensor(float(len(x)), dtype=self.dtype)
-      num_samples = len(x)#tf.convert_to_tensor(len(x), dtype=tf.int32)
+        self.model = model
+        self.strategy = getattr(model, "strategy", tf.distribute.get_strategy())
+        self.reweight_batches = model.loss.reduction != keras.losses.Reduction.SUM
+        self.Xyw = Xyw
+        _build_weight_indices()
 
-      with tf.GradientTape() as outer_tape:
-        with tf.GradientTape() as inner_tape:
-          y_pred = model(x, training=True)
-          batch_loss = model.loss(y, y_pred, sample_weight=sample_weight)
-        grad_slices = [
-          g if g is not None else (0.0 * w)
-          for (g, w) in zip(inner_tape.gradient(batch_loss, model.trainable_variables), model.trainable_variables)
-        ]
-        grads = [tf.cast(tf.convert_to_tensor(g), dtype=self.dtype) for g in grad_slices]
+        if model.run_eagerly:
+            self._fg = self._build_fg()
+            self._reg_fg = self._build_reg_fg()
+            self._hessp = self._build_hessp()
+            self._reg_hessp = self._build_reg_hessp()
+        else:
+            self._fg = tf.function(self._build_fg(), experimental_relax_shapes=True)
+            self._reg_fg = tf.function(
+                self._build_reg_fg(), experimental_relax_shapes=True
+            )
+            self._hessp = tf.function(
+                self._build_hessp(), experimental_relax_shapes=True
+            )
+            self._reg_hessp = tf.function(
+                self._build_reg_hessp(), experimental_relax_shapes=True
+            )
+        self._built = True
+        return self
 
-      batch_hvp = outer_tape.gradient(grads, model.trainable_variables, output_gradients=vec)
-      hvp = tf.cast(tf.dynamic_stitch(self.idx, batch_hvp), dtype=self.dtype)
-      coeff = tf.cast(num_samples if self.reweight_batches else 1, dtype=self.dtype)
-      return coeff * hvp, num_samples
+    def _numpy_to_tensors(self, x):
+        """
+        Convert a (vector) `numpy.ndarray` of parameters to a list of tensors.
 
-    def _fn(vec):
-      n = tf.constant(0, dtype=self.dtype)
-      hvp = tf.zeros(shape=(self.num_model_variables,), dtype=self.dtype)
+        Args:
+          x (numpy.ndarray): vector of parameters used by `scipy.optimize.minimize`
 
-      for k, data in enumerate(self.Xyw):
-        per_replica_hvp, per_replica_n = strategy.run(_per_replica_hessp, args=(data, vec))
-        hvp += strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_hvp, axis=None) 
-        n += strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_n, axis=None)
-      
-      coeff = 1.0 / n if self.reweight_batches else 1.0
-      return tf.cast(coeff, dtype=self.dtype) * hvp
+        Returns:
+          A list of tensors matching the shapes of this object's `model.trainable_weights`
+        """
+        assert self._built
+        parts = tf.dynamic_partition(x, self.part, self.n_tensors)
+        return [tf.reshape(part, self.shapes[k]) for (k, part) in enumerate(parts)]
 
-    return _fn
+    def _tensors_to_numpy(self, weights):
+        """
+        Convert a list of tensors to a (vector) `numpy.ndarray` of parameters.
 
-  @OptimizationStateCache.cached(key='fg')
-  def func_and_grad(self, x):
-    """
-    Evaluate the loss function and its gradient.
-    
-    This method will loop over mini-batches of the training data
-    and compute the loss and gradient in a `tensorflow.GradientTape`
-    for each mini-batch, such that models that require large amounts
-    of memory or large training sets (or both) may be used robustly.
+        Args:
+          weights: list of tensors matching the shapes of this object's `model.trainable_weights`
 
-    Readers familiar with the standard `keras model training procedure <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training.py>`_
-    will note the absence of *regularization losses* provided to
-    ``self.model.compiled_loss``. The regularization terms are computed separately
-    from the loop snippet above, and then added to the loss & gradient values.
-    
-    Please note that providing a `sample_weight` does not necessarily produce a weighted average
-    over the dataset. Rather, like `keras`, the `sample_weight` is applied element-wise to each
-    data sample, and the final total is divided by the number of training examples if the
-    reduction mechanism is `keras.losses.reduction.Reduction.SUM_OVER_BATCH_SIZE`.
-    If an actual weighted average of losses over a dataset is desired, it is the caller's
-    responsibility to ensure that the sum of the values in `sample_weight` is 1.
+        Returns:
+          numpy.ndarray: vector of parameters used by `scipy.optimize.minimize`
+        """
+        assert self._built
+        return tf.cast(tf.dynamic_stitch(self.idx, weights), dtype=self.dtype).numpy()
 
-    Args:
-      x (`numpy.ndarray`): vector at which to evaluate the loss function
+    def get_weights(self):
+        """
+        Retrieve the `model` weights as a `numpy.ndarray` vector.
 
-    Returns:
-      (float, `numpy.ndarray`): value of the loss function and its gradient
-    """
-    assert self._built
-    self.set_weights(x)
-    self.fg_evals += 1
-    (fg, fg_reg) = (self._fg(), self._reg_fg())
-    (f, g) = (fg[0].numpy() + fg_reg[0].numpy(), fg[1].numpy() + fg_reg[1].numpy())
-    return (f, g)
-  
-  def func(self, x):
-    """
-    Evaluate the loss function at `x`.
+        Returns:
+          numpy.ndarray: vector of parameters used by `scipy.optimize.minimize`
+        """
+        assert self._built
+        w = self._tensors_to_numpy(self.model.trainable_variables)
+        return w
 
-    Args:
-      x (`numpy.ndarray`): vector at which to evaluate the loss function
-    Returns:
-      float: the value of the loss function at `x`
-    """
-    return self.func_and_grad(x)[0]
+    def set_weights(self, x):
+        """
+        Set a `keras` model's `model.trainable_weights` (by default, use this object's `model`).
 
-  def grad(self, x):
-    """
-    Evaluate the gradient of the loss function at `x`.
+        Args:
+          x: a `numpy.ndarray` (or similar iterable) parameter vector
+        """
+        assert self._built
+        model = self.model
+        params = tf.dynamic_partition(
+            tf.convert_to_tensor(x),
+            self.part,
+            self.n_tensors,
+        )
+        for i, (shape, param) in enumerate(zip(self.shapes, params)):
+            model.trainable_variables[i].assign(
+                tf.cast(tf.reshape(param, shape), model.trainable_variables[i].dtype)
+            )
 
-    Args:
-      x (`numpy.ndarray`): vector at which to evaluate the loss function
-    Returns:
-      numpy.ndarray: the gradient of the loss function at `x`
-    """
-    return self.func_and_grad(x)[1]
-    
-  def hessp(self, x, vector):
-    """
-    Evaluate the product of the Hessian matrix of the loss function evaluated at `x`
-    with a given `vector` for use in second order optimization methods.
+    def _build_reg_fg(self):
+        """
+        Create a callable to evaluate the regularization component of the loss function
+        which may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
+        Before the callable may be executed, the model's weights must be set with
+        this object's `set_weights()` method.
 
-    The implementation here has been adapted from the Hessian-vector-product 
-    benchmarking suite in `tensorflow`, available
-    `here <https://github.com/tensorflow/tensorflow/commit/5b37e7ed14eb7dddae8a0e87435595347a315bb7>`_.
-    
-    The computation of the Hessian is performed over mini-batches and accumulated,
-    as described in the docstring for the method `func_and_grad`.
+        Returns:
+          callable (with no arguments)
+        """
+        (model, strategy) = (self.model, self.strategy)
 
-    Args:
-      x (numpy.ndarray): point at which to evaluate the loss function
-      vector (numpy.ndarray): direction vector to project the Hessian onto
-    Returns:
-      numpy.ndarray: the Hessian vector product
-    """
-    assert self._built
-    self.hessp_evals += 1
-    self.set_weights(x)
-    vec = self._numpy_to_tensors(vector)
-    return self._hessp(vec).numpy() + self._reg_hessp(vec).numpy()
+        def _fn():
+            def _distrib_fn():
+                z = tf.convert_to_tensor([0.0])
+                with tf.GradientTape() as tape:
+                    reg_loss = math_ops.add_n(model.losses)
+                reg_grad = [
+                    g if g is not None else (0 * w)
+                    for (g, w) in zip(
+                        tape.gradient(reg_loss, model.trainable_variables),
+                        model.trainable_variables,
+                    )
+                ]
+                reg_grad = tf.cast(
+                    tf.dynamic_stitch(self.idx, reg_grad), dtype=self.dtype
+                )
+                return reg_loss, reg_grad
 
-  def minimize(self, epochs=1, callback=None, pretrain_fn=None, **kwargs):
-    raise NotImplementedError
+            result = strategy.run(_distrib_fn, args=())
+            return training.reduce_per_replica(result, strategy, "first")
+
+        return _fn
+
+    def _build_fg(self):
+        """
+        Create a callable to evaluate the sample loss component of the loss function
+        which may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
+        Before the callable may be executed, the model's weights must be set with
+        this object's `set_weights()` method.
+
+        Please note that the function `model.loss()` is evaluated rather than the
+        `model.compiled_loss()`. Since we accumulate each batch's loss over the entire
+        training set, there is no need to perform the additional loss metric
+        computations that happen in the `LossesContainer`.
+
+        Returns:
+          callable (with no arguments)
+        """
+        (model, strategy) = (self.model, self.strategy)
+
+        def _per_replica_fg(data):
+            data = data_adapter.expand_1d(data)
+            x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
+            num_samples = len(x)
+
+            with tf.GradientTape() as tape:
+                y_pred = model(x, training=True)
+                batch_loss = model.loss(y, y_pred, sample_weight=sample_weight)
+
+            # calculate gradients and convert to 1D tf.Tensor
+            batch_grad = tape.gradient(batch_loss, model.trainable_variables)
+            batch_grad = tf.cast(
+                tf.dynamic_stitch(self.idx, batch_grad), dtype=self.dtype
+            )
+
+            coeff = tf.cast(
+                num_samples if self.reweight_batches else 1.0, dtype=self.dtype
+            )
+            return (
+                coeff * tf.cast(batch_loss, self.dtype),
+                coeff * batch_grad,
+                num_samples,
+            )
+
+        def _fn():
+            n = tf.constant(0, dtype=tf.int32)
+            loss = tf.constant(0.0, dtype=self.dtype)
+            grad = tf.zeros(shape=(self.num_model_variables,), dtype=self.dtype)
+
+            for data in iter(self.Xyw):
+                per_replica_loss, per_replica_grad, per_replica_n = strategy.run(
+                    _per_replica_fg, args=(data,)
+                )
+                loss += strategy.reduce(
+                    tf.distribute.ReduceOp.SUM, per_replica_loss, axis=None
+                )
+                grad += strategy.reduce(
+                    tf.distribute.ReduceOp.SUM, per_replica_grad, axis=None
+                )
+                n += strategy.reduce(
+                    tf.distribute.ReduceOp.SUM, per_replica_n, axis=None
+                )
+
+            coeff = (
+                (1.0 / tf.cast(n, dtype=self.dtype)) if self.reweight_batches else 1.0
+            )
+            return (coeff * loss), (coeff * grad)
+
+        return _fn
+
+    def _build_reg_hessp(self):
+        """
+        Create a callable to evaluate the regularization component of the HVP, which
+        may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
+        Before the callable may be executed, the model's weights must be set with
+        this object's `set_weights()` method.
+
+        Returns:
+          callable taking 1 argument; a `tf.Tensor` representing the vector in the HVP
+        """
+        (model, strategy) = (self.model, self.strategy)
+
+        def _fn(vec):
+            def _distrib_fn(vec):
+                z = tf.zeros(shape=(1,), dtype=self.dtype)
+                with tf.GradientTape() as outer_tape:
+                    with tf.GradientTape() as inner_tape:
+                        reg_loss = math_ops.add_n(model.losses)
+                    reg_grad_slices = [
+                        g if g is not None else (0.0 * w)
+                        for (g, w) in zip(
+                            inner_tape.gradient(reg_loss, model.trainable_variables),
+                            model.trainable_variables,
+                        )
+                    ]
+                    reg_grads = [
+                        tf.cast(tf.convert_to_tensor(g), dtype=self.dtype)
+                        for g in reg_grad_slices
+                    ]
+
+                reg_hvp = outer_tape.gradient(
+                    reg_grads, model.trainable_variables, output_gradients=vec
+                )
+                reg_hvp = tf.dynamic_stitch(self.idx, reg_hvp)
+                return reg_hvp
+
+            result = strategy.run(_distrib_fn, args=(vec,))
+            return training.reduce_per_replica(result, strategy, "first")
+
+        return _fn
+
+    def _build_hessp(self):
+        """
+        Create a callable to evaluate the sample loss component of the HVP, which
+        may be wrapped in a tensorflow function (similar to a ``@tf.function` decorator).
+        Before the callable may be executed, the model's weights must be set with
+        this object's `set_weights()` method.
+
+        Please note that the function `model.loss()` is evaluated rather than the
+        `model.compiled_loss()`. Since we accumulate each batch's loss over the entire
+        training set, there is no need to perform the additional loss metric
+        computations that happen in the `LossesContainer`.
+
+        Returns:
+          callable taking 1 argument; a `tf.Tensor` representing the vector in the HVP
+        """
+        (model, strategy) = (self.model, self.strategy)
+
+        def _per_replica_hessp(data, vec):
+            data = data_adapter.expand_1d(data)
+            x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
+            # num_samples = tf.convert_to_tensor(float(len(x)), dtype=self.dtype)
+            num_samples = len(x)  # tf.convert_to_tensor(len(x), dtype=tf.int32)
+
+            with tf.GradientTape() as outer_tape:
+                with tf.GradientTape() as inner_tape:
+                    y_pred = model(x, training=True)
+                    batch_loss = model.loss(y, y_pred, sample_weight=sample_weight)
+                grad_slices = [
+                    g if g is not None else (0.0 * w)
+                    for (g, w) in zip(
+                        inner_tape.gradient(batch_loss, model.trainable_variables),
+                        model.trainable_variables,
+                    )
+                ]
+                grads = [
+                    tf.cast(tf.convert_to_tensor(g), dtype=self.dtype)
+                    for g in grad_slices
+                ]
+
+            batch_hvp = outer_tape.gradient(
+                grads, model.trainable_variables, output_gradients=vec
+            )
+            hvp = tf.cast(tf.dynamic_stitch(self.idx, batch_hvp), dtype=self.dtype)
+            coeff = tf.cast(
+                num_samples if self.reweight_batches else 1, dtype=self.dtype
+            )
+            return coeff * hvp, num_samples
+
+        def _fn(vec):
+            n = tf.constant(0, dtype=self.dtype)
+            hvp = tf.zeros(shape=(self.num_model_variables,), dtype=self.dtype)
+
+            for k, data in enumerate(self.Xyw):
+                per_replica_hvp, per_replica_n = strategy.run(
+                    _per_replica_hessp, args=(data, vec)
+                )
+                hvp += strategy.reduce(
+                    tf.distribute.ReduceOp.SUM, per_replica_hvp, axis=None
+                )
+                n += strategy.reduce(
+                    tf.distribute.ReduceOp.SUM, per_replica_n, axis=None
+                )
+
+            coeff = 1.0 / n if self.reweight_batches else 1.0
+            return tf.cast(coeff, dtype=self.dtype) * hvp
+
+        return _fn
+
+    @OptimizationStateCache.cached(key="fg")
+    def func_and_grad(self, x):
+        """
+        Evaluate the loss function and its gradient.
+
+        This method will loop over mini-batches of the training data
+        and compute the loss and gradient in a `tensorflow.GradientTape`
+        for each mini-batch, such that models that require large amounts
+        of memory or large training sets (or both) may be used robustly.
+
+        Readers familiar with the standard `keras model training procedure <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training.py>`_
+        will note the absence of *regularization losses* provided to
+        ``self.model.compiled_loss``. The regularization terms are computed separately
+        from the loop snippet above, and then added to the loss & gradient values.
+
+        Please note that providing a `sample_weight` does not necessarily produce a weighted average
+        over the dataset. Rather, like `keras`, the `sample_weight` is applied element-wise to each
+        data sample, and the final total is divided by the number of training examples if the
+        reduction mechanism is `keras.losses.reduction.Reduction.SUM_OVER_BATCH_SIZE`.
+        If an actual weighted average of losses over a dataset is desired, it is the caller's
+        responsibility to ensure that the sum of the values in `sample_weight` is 1.
+
+        Args:
+          x (`numpy.ndarray`): vector at which to evaluate the loss function
+
+        Returns:
+          (float, `numpy.ndarray`): value of the loss function and its gradient
+        """
+        assert self._built
+        self.set_weights(x)
+        self.fg_evals += 1
+        (fg, fg_reg) = (self._fg(), self._reg_fg())
+        (f, g) = (fg[0].numpy() + fg_reg[0].numpy(), fg[1].numpy() + fg_reg[1].numpy())
+        return (f, g)
+
+    def func(self, x):
+        """
+        Evaluate the loss function at `x`.
+
+        Args:
+          x (`numpy.ndarray`): vector at which to evaluate the loss function
+        Returns:
+          float: the value of the loss function at `x`
+        """
+        return self.func_and_grad(x)[0]
+
+    def grad(self, x):
+        """
+        Evaluate the gradient of the loss function at `x`.
+
+        Args:
+          x (`numpy.ndarray`): vector at which to evaluate the loss function
+        Returns:
+          numpy.ndarray: the gradient of the loss function at `x`
+        """
+        return self.func_and_grad(x)[1]
+
+    def hessp(self, x, vector):
+        """
+        Evaluate the product of the Hessian matrix of the loss function evaluated at `x`
+        with a given `vector` for use in second order optimization methods.
+
+        The implementation here has been adapted from the Hessian-vector-product
+        benchmarking suite in `tensorflow`, available
+        `here <https://github.com/tensorflow/tensorflow/commit/5b37e7ed14eb7dddae8a0e87435595347a315bb7>`_.
+
+        The computation of the Hessian is performed over mini-batches and accumulated,
+        as described in the docstring for the method `func_and_grad`.
+
+        Args:
+          x (numpy.ndarray): point at which to evaluate the loss function
+          vector (numpy.ndarray): direction vector to project the Hessian onto
+        Returns:
+          numpy.ndarray: the Hessian vector product
+        """
+        assert self._built
+        self.hessp_evals += 1
+        self.set_weights(x)
+        vec = self._numpy_to_tensors(vector)
+        return self._hessp(vec).numpy() + self._reg_hessp(vec).numpy()
+
+    def minimize(self, epochs=1, callback=None, pretrain_fn=None, **kwargs):
+        raise NotImplementedError
 
 
 class ScipyBatchOptimizer(BatchOptimizer):
-  """
-  A `BatchOptimizer` that wraps the `scipy.optimize.minimize <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html>`_
-  library for multivariate gradient-based optimization.
-  """
-  DEFAULT_METHOD = "L-BFGS-B"
-
-  def __init__(
-    self,
-    name="scipy",
-    method=None,
-    epochs=None,
-    pretrain_fn=None,
-    options=None,
-    bounds=None,
-    constraints=None,
-    tol=None,
-    **kwargs
-  ):
     """
-    Initialize a `ScipyBatchOptimizer` and store any default arguments to pass to
-    `scipy.minimize.optimize`. Arguments may be passed either here in the constructor
-    or directly in `minimize()`, which takes precedence.
-
-    The ability to pass solver arguments to the constructor here is a mechanism for
-    interoperability with `KerasTuner`, such that hyperparameter search over the
-    solver configurations could be performed if desired. 
-
-    Args:
-      epochs (int or list[int]): number of maximum iterations to perform.
-        This will be passed as `options['maxiters']` to `scipy`.
-      callback (callable): univariate callable function to be executed at the end of each iteration.
-        The argument to this function is the current `np.ndarray` parameter vector. 
-      pretrain_fn (callable): univariate callable function to be executed at the end of each iteration.
-        The argument to this function is the `model` instance. This may be used in conjuction with
-        a list-like `method` to modify a model or set certain model layers as trainable or not trainable
-        in an alternating fashion.
-      method (str or list[str]): method to use for optimization
-      options (dict or list[dict]): dictionary payload of options to configure an optimization algorithm
-      bounds (sequence or `scipy.optimize.Bounds`):
-        Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
-        trust-constr methods. Please see the `scipy.optimize.minimize` docstring for details.
-        Please note that the `bounds` specified are used as-is for successive calls to `minimize`,
-        even if the `pretrain_fn` has modified the model's architecture.
-      constraints: Constraints definition for the COBYLA, SLSQP and trust-constr solvers. 
-        Please see the `scipy.optimize.minimize` docstring for details.
-        Please note that the `constraints` specified are used as-is for successive calls to `minimize`,
-        even if the `pretrain_fn` has modified the model's architecture.
-      tol (float): Numerical tolerance for termination. When `tol` is specified, the selected solver 
-        sets the relevant solver-specific tolerance(s) equal to `tol`. For detailed control, set the
-        solver-specific configuration value through `options`.
+    A `BatchOptimizer` that wraps the `scipy.optimize.minimize <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html>`_
+    library for multivariate gradient-based optimization.
     """
-    if method is not None and method not in OPTIMIZER_IDENTIFIERS:
-      raise ValueError(f"Provided method {method} is not in {OPTIMIZER_IDENTIFIERS}")
-    self.method = method or self.DEFAULT_METHOD
-    self.epochs = epochs
-    self.pretrain_fn = pretrain_fn
-    self.options = options
-    self.bounds = bounds
-    self.constraints = constraints
-    self.tol = tol
-    super().__init__(name=name, **kwargs)
 
-  def minimize(
-    self,
-    epochs=10,
-    callback=None,
-    pretrain_fn=None,
-    method=None,
-    options=None,
-    bounds=None,
-    constraints=None,
-    tol=None
-  ):
-    """
-    Minimize the loss function for a compiled `model` using an algorithm 
-    from `scipy.optimize.minimize`.
+    DEFAULT_METHOD = "L-BFGS-B"
 
-    The arguments to this method replicate those of the `scipy.optimize` and may be used analogously.
-    However it is also possible to pass *list* values for the following arguments:
+    def __init__(
+        self,
+        name="scipy",
+        method=None,
+        epochs=None,
+        pretrain_fn=None,
+        options=None,
+        bounds=None,
+        constraints=None,
+        tol=None,
+        **kwargs,
+    ):
+        """
+        Initialize a `ScipyBatchOptimizer` and store any default arguments to pass to
+        `scipy.minimize.optimize`. Arguments may be passed either here in the constructor
+        or directly in `minimize()`, which takes precedence.
 
-    - `epochs`
-    - `method`
-    - `options`
+        The ability to pass solver arguments to the constructor here is a mechanism for
+        interoperability with `KerasTuner`, such that hyperparameter search over the
+        solver configurations could be performed if desired.
 
-    When lists are provided, this will result in *multiple* successive calls to `scipy.optimize.minize`
-    using the `method` and `options` requested, allowing for combinations of algorithms to be used.
-    The result of one method will be passed in a daisy chain as the initial value for the next method.
+        Args:
+          epochs (int or list[int]): number of maximum iterations to perform.
+            This will be passed as `options['maxiters']` to `scipy`.
+          callback (callable): univariate callable function to be executed at the end of each iteration.
+            The argument to this function is the current `np.ndarray` parameter vector.
+          pretrain_fn (callable): univariate callable function to be executed at the end of each iteration.
+            The argument to this function is the `model` instance. This may be used in conjuction with
+            a list-like `method` to modify a model or set certain model layers as trainable or not trainable
+            in an alternating fashion.
+          method (str or list[str]): method to use for optimization
+          options (dict or list[dict]): dictionary payload of options to configure an optimization algorithm
+          bounds (sequence or `scipy.optimize.Bounds`):
+            Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
+            trust-constr methods. Please see the `scipy.optimize.minimize` docstring for details.
+            Please note that the `bounds` specified are used as-is for successive calls to `minimize`,
+            even if the `pretrain_fn` has modified the model's architecture.
+          constraints: Constraints definition for the COBYLA, SLSQP and trust-constr solvers.
+            Please see the `scipy.optimize.minimize` docstring for details.
+            Please note that the `constraints` specified are used as-is for successive calls to `minimize`,
+            even if the `pretrain_fn` has modified the model's architecture.
+          tol (float): Numerical tolerance for termination. When `tol` is specified, the selected solver
+            sets the relevant solver-specific tolerance(s) equal to `tol`. For detailed control, set the
+            solver-specific configuration value through `options`.
+        """
+        if method is not None and method not in OPTIMIZER_IDENTIFIERS:
+            raise ValueError(
+                f"Provided method {method} is not in {OPTIMIZER_IDENTIFIERS}"
+            )
+        self.method = method or self.DEFAULT_METHOD
+        self.epochs = epochs
+        self.pretrain_fn = pretrain_fn
+        self.options = options
+        self.bounds = bounds
+        self.constraints = constraints
+        self.tol = tol
+        super().__init__(name=name, **kwargs)
 
-    Args:
-      epochs (int or list[int]): number of maximum iterations to perform.
-        This will be passed as `options['maxiters']` to `scipy`.
-      callback (callable): univariate callable function to be executed at the end of each iteration.
-        The argument to this function is the current `np.ndarray` parameter vector. 
-      pretrain_fn (callable): univariate callable function to be executed at the end of each iteration.
-        The argument to this function is the `model` instance. This may be used in conjuction with
-        a list-like `method` to modify a model or set certain model layers as trainable or not trainable
-        in an alternating fashion.
-      method (str or list[str]): method to use for optimization
-      options (dict or list[dict]): dictionary payload of options to configure an optimization algorithm
-      bounds (sequence or `scipy.optimize.Bounds`):
-        Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
-        trust-constr methods. Please see the `scipy.optimize.minimize` docstring for details.
-        Please note that the `bounds` specified are used as-is for successive calls to `minimize`,
-        even if the `pretrain_fn` has modified the model's architecture.
-      constraints: Constraints definition for the COBYLA, SLSQP and trust-constr solvers. 
-        Please see the `scipy.optimize.minimize` docstring for details.
-        Please note that the `constraints` specified are used as-is for successive calls to `minimize`,
-        even if the `pretrain_fn` has modified the model's architecture.
-      tol (float): Numerical tolerance for termination. When `tol` is specified, the selected solver 
-        sets the relevant solver-specific tolerance(s) equal to `tol`. For detailed control, set the
-        solver-specific configuration value through `options`.
-    Returns:
-      `scipy.optimize.OptimizeResult`
-    """
-    assert self._built
-    if callback is not None:
-      assert callable(callback), "Provided callback is not callable"
+    def minimize(
+        self,
+        epochs=10,
+        callback=None,
+        pretrain_fn=None,
+        method=None,
+        options=None,
+        bounds=None,
+        constraints=None,
+        tol=None,
+    ):
+        """
+        Minimize the loss function for a compiled `model` using an algorithm
+        from `scipy.optimize.minimize`.
 
-    # Resolve the method arguments with any defaults provided to the constructor
-    epochs = epochs or self.epochs
-    options = options or self.options
-    method = method or self.method
-    pretrain_fn = pretrain_fn or self.pretrain_fn
-    bounds = bounds or self.bounds
-    constraints = constraints or self.constraints
+        The arguments to this method replicate those of the `scipy.optimize` and may be used analogously.
+        However it is also possible to pass *list* values for the following arguments:
 
-    # Convert scalars to lists to allow for a suite of optimization methods to be applied successively
-    epochs = epochs if type(epochs) is list else [epochs]
-    options = options if type(options) is list else len(epochs) * [options or {}]
-    method = method if type(method) is list else len(epochs) * [method or self.method]
-    pretrain_fn = pretrain_fn if type(pretrain_fn) is list else len(epochs) * [pretrain_fn]
+        - `epochs`
+        - `method`
+        - `options`
 
-    # Create a list of config dicts to pass to scipy.optimize.minimize successively
-    minimize_configs = []
-    for k, e in enumerate(epochs):
-      config = {
-        'options': deepcopy(options[k]),
-        'method': method[k],
-        # 'bounds': bounds,
-        # 'constraints': constraints,
-        'tol': tol,
-        'pretrain_fn': pretrain_fn[k],
-      }
-      config['options']['maxiter'] = e
-      minimize_configs.append(config)
+        When lists are provided, this will result in *multiple* successive calls to `scipy.optimize.minize`
+        using the `method` and `options` requested, allowing for combinations of algorithms to be used.
+        The result of one method will be passed in a daisy chain as the initial value for the next method.
 
-    def sigint_handler():
-      x = self.get_weights()
-      return scipy.optimize.OptimizeResult(
-        x=x,
-        success=False,
-        status=-1,
-        message="User aborted optimization",
-        fun=self.func(x),
-        grad=self.grad(x),
-        nit=-1,
-        maxcv=None,
-      )
+        Args:
+          epochs (int or list[int]): number of maximum iterations to perform.
+            This will be passed as `options['maxiters']` to `scipy`.
+          callback (callable): univariate callable function to be executed at the end of each iteration.
+            The argument to this function is the current `np.ndarray` parameter vector.
+          pretrain_fn (callable): univariate callable function to be executed at the end of each iteration.
+            The argument to this function is the `model` instance. This may be used in conjuction with
+            a list-like `method` to modify a model or set certain model layers as trainable or not trainable
+            in an alternating fashion.
+          method (str or list[str]): method to use for optimization
+          options (dict or list[dict]): dictionary payload of options to configure an optimization algorithm
+          bounds (sequence or `scipy.optimize.Bounds`):
+            Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
+            trust-constr methods. Please see the `scipy.optimize.minimize` docstring for details.
+            Please note that the `bounds` specified are used as-is for successive calls to `minimize`,
+            even if the `pretrain_fn` has modified the model's architecture.
+          constraints: Constraints definition for the COBYLA, SLSQP and trust-constr solvers.
+            Please see the `scipy.optimize.minimize` docstring for details.
+            Please note that the `constraints` specified are used as-is for successive calls to `minimize`,
+            even if the `pretrain_fn` has modified the model's architecture.
+          tol (float): Numerical tolerance for termination. When `tol` is specified, the selected solver
+            sets the relevant solver-specific tolerance(s) equal to `tol`. For detailed control, set the
+            solver-specific configuration value through `options`.
+        Returns:
+          `scipy.optimize.OptimizeResult`
+        """
+        assert self._built
+        if callback is not None:
+            assert callable(callback), "Provided callback is not callable"
 
-    try:
-      for config in minimize_configs:
-        _fn = config.pop('pretrain_fn')
-        if callable(_fn):
-          _fn(self.model)
-          # Rebuild the optimize in case the pretrain_fn has modified the model
-          self.build(self.model, self.Xyw)
+        # Resolve the method arguments with any defaults provided to the constructor
+        epochs = epochs or self.epochs
+        options = options or self.options
+        method = method or self.method
+        pretrain_fn = pretrain_fn or self.pretrain_fn
+        bounds = bounds or self.bounds
+        constraints = constraints or self.constraints
 
-        result = scipy.optimize.minimize(
-          fun=self.func,
-          x0=np.array(self.get_weights().ravel(), np.float64),
-          jac=self.grad,
-          hessp=self.hessp,
-          callback=callback,
-          **config,
+        # Convert scalars to lists to allow for a suite of optimization methods to be applied successively
+        epochs = epochs if type(epochs) is list else [epochs]
+        options = options if type(options) is list else len(epochs) * [options or {}]
+        method = (
+            method if type(method) is list else len(epochs) * [method or self.method]
         )
-        self.set_weights(result.x)
-        if result.nit == 0 and callback is not None:
-          callback(self.get_weights())
+        pretrain_fn = (
+            pretrain_fn if type(pretrain_fn) is list else len(epochs) * [pretrain_fn]
+        )
 
-        self.results.append(result)
-    # This is an advanced implementation of early stopping combined
-    # with "human in the loop" interative machine learning.
-    except KeyboardInterrupt:
-      result = sigint_handler()
-      self.results.append(result)
+        # Create a list of config dicts to pass to scipy.optimize.minimize successively
+        minimize_configs = []
+        for k, e in enumerate(epochs):
+            config = {
+                "options": deepcopy(options[k]),
+                "method": method[k],
+                # 'bounds': bounds,
+                # 'constraints': constraints,
+                "tol": tol,
+                "pretrain_fn": pretrain_fn[k],
+            }
+            config["options"]["maxiter"] = e
+            minimize_configs.append(config)
 
-    return self.get_weights()
+        def sigint_handler():
+            x = self.get_weights()
+            return scipy.optimize.OptimizeResult(
+                x=x,
+                success=False,
+                status=-1,
+                message="User aborted optimization",
+                fun=self.func(x),
+                grad=self.grad(x),
+                nit=-1,
+                maxcv=None,
+            )
+
+        try:
+            for config in minimize_configs:
+                _fn = config.pop("pretrain_fn")
+                if callable(_fn):
+                    _fn(self.model)
+                    # Rebuild the optimize in case the pretrain_fn has modified the model
+                    self.build(self.model, self.Xyw)
+
+                result = scipy.optimize.minimize(
+                    fun=self.func,
+                    x0=np.array(self.get_weights().ravel(), np.float64),
+                    jac=self.grad,
+                    hessp=self.hessp,
+                    callback=callback,
+                    **config,
+                )
+                self.set_weights(result.x)
+                if result.nit == 0 and callback is not None:
+                    callback(self.get_weights())
+
+                self.results.append(result)
+        # This is an advanced implementation of early stopping combined
+        # with "human in the loop" interative machine learning.
+        except KeyboardInterrupt:
+            result = sigint_handler()
+            self.results.append(result)
+
+        return self.get_weights()
 
 
-OPTIMIZER_IDENTIFIER_MAP = dict(**{
-  'scipy': (ScipyBatchOptimizer, (), {}),
-}, **{
-  method.lower(): (ScipyBatchOptimizer, (), {'name': method.lower(), 'method': method.upper()}) 
-  for method in MINIMIZE_METHODS
-}, **{
-  method.upper(): (ScipyBatchOptimizer, (), {'name': method.lower(), 'method': method.upper()}) 
-  for method in MINIMIZE_METHODS
-})
+OPTIMIZER_IDENTIFIER_MAP = dict(
+    **{
+        "scipy": (ScipyBatchOptimizer, (), {}),
+    },
+    **{
+        method.lower(): (
+            ScipyBatchOptimizer,
+            (),
+            {"name": method.lower(), "method": method.upper()},
+        )
+        for method in MINIMIZE_METHODS
+    },
+    **{
+        method.upper(): (
+            ScipyBatchOptimizer,
+            (),
+            {"name": method.lower(), "method": method.upper()},
+        )
+        for method in MINIMIZE_METHODS
+    },
+)
+
 
 def get(identifier):
-  """
-  Return an instantiated `kormos.optimizers.BatchOptimizer`.
+    """
+    Return an instantiated `kormos.optimizers.BatchOptimizer`.
 
-  Args:
-    identifier (str or `kormos.optimizers.BatchOptimizer`): A string identifier
-      to use to create a `BatchOptimizer`. May be either 'scipy' or the name of a
-      specific `method` implemented by ``scipy.optimize.minimize(method=<name>)``
-      
-  """
-  if isinstance(identifier, BatchOptimizer):
-    return identifier
-  if isinstance(identifier, str):
-    if identifier not in OPTIMIZER_IDENTIFIER_MAP:
-      raise ValueError(
-        f"Provided identifier='{identifier}' is a valid string. Allowed values: {list(OPTIMIZER_IDENTIFIER_MAP.keys())}"
-      )
-    (cls, args, kwargs) = OPTIMIZER_IDENTIFIER_MAP[identifier]
-    return cls(*args, **kwargs)
-  raise ValueError(f"Could not interpret optimizer identifier: {identifier}") 
+    Args:
+      identifier (str or `kormos.optimizers.BatchOptimizer`): A string identifier
+        to use to create a `BatchOptimizer`. May be either 'scipy' or the name of a
+        specific `method` implemented by ``scipy.optimize.minimize(method=<name>)``
+
+    """
+    if isinstance(identifier, BatchOptimizer):
+        return identifier
+    if isinstance(identifier, str):
+        if identifier not in OPTIMIZER_IDENTIFIER_MAP:
+            raise ValueError(
+                f"Provided identifier='{identifier}' is a valid string. Allowed values: {list(OPTIMIZER_IDENTIFIER_MAP.keys())}"
+            )
+        (cls, args, kwargs) = OPTIMIZER_IDENTIFIER_MAP[identifier]
+        return cls(*args, **kwargs)
+    raise ValueError(f"Could not interpret optimizer identifier: {identifier}")

--- a/kormos/utils/cache.py
+++ b/kormos/utils/cache.py
@@ -28,71 +28,69 @@ import tensorflow as tf
 
 
 class OptimizationStateCache(object):
+    def __init__(self, max_entries=100):
+        assert max_entries > 0
+        self.max_entries = max_entries
+        self.state_dict = {}
+        self.entries = []
 
-  def __init__(self, max_entries=100):
-    assert max_entries > 0
-    self.max_entries = max_entries
-    self.state_dict = {}
-    self.entries = []
+    @staticmethod
+    def hash(x):
+        if type(x) is tf.Tensor:
+            h = OptimizationStateCache.hash(x.numpy())
+        if type(x) is np.ndarray:
+            h = hex(hash(x.tobytes()))
+        else:
+            h = x
+        return h
 
-  @staticmethod
-  def hash(x):
-    if type(x) is tf.Tensor:
-      h = OptimizationStateCache.hash(x.numpy())
-    if type(x) is np.ndarray:
-      h = hex(hash(x.tobytes()))
-    else:
-      h = x
-    return h
+    def clear(self):
+        del self.state_dict
+        del self.entries
+        self.state_dict = {}
+        self.entries = []
 
-  def clear(self):
-    del self.state_dict
-    del self.entries
-    self.state_dict = {}
-    self.entries = []
+    def _delete_oldest_entry(self):
+        if len(self.entries) == self.max_entries:
+            self.entries.reverse()
+            state_key = self.entries.pop()
+            self.entries.reverse()
+            del self.state_dict[state_key]
 
-  def _delete_oldest_entry(self):
-    if len(self.entries) == self.max_entries:
-      self.entries.reverse()
-      state_key = self.entries.pop()
-      self.entries.reverse()
-      del self.state_dict[state_key]
+    def update(self, x, **kwargs):
+        state_key = self.hash(x)
 
-  def update(self, x, **kwargs):
-    state_key = self.hash(x)
+        if state_key not in self.state_dict:
+            self._delete_oldest_entry()
+            self.entries.append(state_key)
 
-    if state_key not in self.state_dict:
-      self._delete_oldest_entry()
-      self.entries.append(state_key)
+        state = self.state_dict.pop(state_key, {"x": copy.deepcopy(x)})
+        state.update({key: copy.deepcopy(val) for (key, val) in kwargs.items()})
+        self.state_dict[state_key] = state
 
-    state = self.state_dict.pop(state_key, {'x': copy.deepcopy(x)})
-    state.update({
-      key: copy.deepcopy(val) 
-      for (key, val) in kwargs.items()
-    })
-    self.state_dict[state_key] = state
+    def get(self, x, key):
+        state_key = self.hash(x)
+        state = self.state_dict.get(state_key, {})
+        return state.get(key)
 
-  def get(self, x, key):
-    state_key = self.hash(x)
-    state = self.state_dict.get(state_key, {})
-    return state.get(key)
+    def get_last(self, key, k=-1):
+        state_key = self.entries[k]
+        state = self.state_dict.get(state_key, {})
+        return state.get(key)
 
-  def get_last(self, key, k=-1):
-    state_key = self.entries[k]
-    state = self.state_dict.get(state_key, {})
-    return state.get(key)
+    @staticmethod
+    def cached(key, max_entries=10, cache_name="cache"):
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(self, x, *args, **kwargs):
+                cache = getattr(self, cache_name)
+                cached_value = cache.get(x, key)
+                if cached_value is not None:
+                    return cached_value
+                value = func(self, x, *args, **kwargs)
+                cache.update(x, **{key: value})
+                return value
 
-  @staticmethod
-  def cached(key, max_entries=10, cache_name='cache'):
-    def decorator(func):
-      @functools.wraps(func)
-      def wrapper(self, x, *args, **kwargs):
-        cache = getattr(self, cache_name)
-        cached_value = cache.get(x, key)
-        if cached_value is not None:
-          return cached_value
-        value = func(self, x, *args, **kwargs)
-        cache.update(x, **{key: value})
-        return value
-      return wrapper
-    return decorator
+            return wrapper
+
+        return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ keras
 keras-tuner
 sphinx
 sphinx-rtd-theme
+black

--- a/tests/kormos/test_models.py
+++ b/tests/kormos/test_models.py
@@ -27,6 +27,7 @@ import numpy as np
 
 import tensorflow as tf
 from tensorflow import keras
+
 from tensorflow.keras.regularizers import L1, L2
 from tensorflow.python.keras.engine import data_adapter
 
@@ -44,6 +45,8 @@ except ImportError:
 
 
 class TestBatchOptimizedModel:
+
+  keras.backend.set_floatx("float64")
 
   def test_stochastic_optimizer(self):
     """
@@ -93,7 +96,7 @@ class TestBatchOptimizedModel:
       outputs=model_output,
     )
     loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer=optimizer)
+    model.compile(loss=loss, optimizer=optimizer, run_eagerly=False)
     assert model.fit == model.fit_batch
 
     np.random.seed(1)
@@ -131,7 +134,7 @@ class TestBatchOptimizedSequentialModel:
       kernel_initializer="ones",
     ))
     loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer="adam")
+    model.compile(loss=loss, optimizer="adam", run_eagerly=False)
     assert model.fit != model.fit_batch
 
     np.random.seed(1)
@@ -155,7 +158,7 @@ class TestBatchOptimizedSequentialModel:
       kernel_initializer="ones",
     ))
     loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer=optimizer)
+    model.compile(loss=loss, optimizer=optimizer, run_eagerly=False)
     assert model.fit == model.fit_batch
 
     np.random.seed(1)
@@ -197,7 +200,12 @@ class TestBatchOptimizedSequentialModel:
         kernel_initializer="ones",
       ))
       loss = keras.losses.MeanSquaredError()
-      model.compile(loss=loss, optimizer="cg", metrics=[keras.metrics.RootMeanSquaredError()])
+      model.compile(
+        loss=loss,
+        optimizer="cg",
+        metrics=[keras.metrics.RootMeanSquaredError()],
+        run_eagerly=False,
+      )
       return model
 
     # Generate data from a high rank linear model (relative to # of units in hidden layer)

--- a/tests/kormos/test_models.py
+++ b/tests/kormos/test_models.py
@@ -35,198 +35,240 @@ from kormos.models import BatchOptimizedModel, BatchOptimizedSequentialModel
 from kormos.optimizers import ScipyBatchOptimizer
 
 try:
-  import keras_tuner
-  HAS_KERAS_TUNER = True
+    import keras_tuner
+
+    HAS_KERAS_TUNER = True
 except ImportError:
-  HAS_KERAS_TUNER = False
-  logging.error(
-    "Could not import keras_tuner to test interoperability. Please verify dependencies."
-  )
+    HAS_KERAS_TUNER = False
+    logging.error(
+        "Could not import keras_tuner to test interoperability. Please verify dependencies."
+    )
 
 
 class TestBatchOptimizedModel:
 
-  keras.backend.set_floatx("float64")
+    keras.backend.set_floatx("float64")
 
-  def test_stochastic_optimizer(self):
-    """
-    Ensure that the standard keras fit() interface is used if the optimizer
-    provided to compile() is a standard (stochastic) optimizer.
-    """
-    rank = 5
-    model_input = keras.Input(shape=(rank,), name="input")
-    model_output = keras.layers.Dense(
-      units=1,
-      input_shape=(rank,),
-      activation=None,
-      use_bias=False,
-      kernel_regularizer=L2(1e-3),
-      kernel_initializer="ones",
-    )(model_input)
-    model = BatchOptimizedModel(
-      inputs=model_input,
-      outputs=model_output,
-    )
-    loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer="adam")
-    assert model.fit != model.fit_batch
+    def test_stochastic_optimizer(self):
+        """
+        Ensure that the standard keras fit() interface is used if the optimizer
+        provided to compile() is a standard (stochastic) optimizer.
+        """
+        rank = 5
+        model_input = keras.Input(shape=(rank,), name="input")
+        model_output = keras.layers.Dense(
+            units=1,
+            input_shape=(rank,),
+            activation=None,
+            use_bias=False,
+            kernel_regularizer=L2(1e-3),
+            kernel_initializer="ones",
+        )(model_input)
+        model = BatchOptimizedModel(
+            inputs=model_input,
+            outputs=model_output,
+        )
+        loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
+        model.compile(loss=loss, optimizer="adam")
+        assert model.fit != model.fit_batch
 
-    np.random.seed(1)
-    w = np.random.normal(size=rank)
-    X = np.random.normal(size=(1000, rank))
-    y = X.dot(w)
-    model.fit(X, y, epochs=200)
-    actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
-    assert np.allclose(actual, w, atol=1e-2)
+        np.random.seed(1)
+        w = np.random.normal(size=rank)
+        X = np.random.normal(size=(1000, rank))
+        y = X.dot(w)
+        model.fit(X, y, epochs=200)
+        actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
+        assert np.allclose(actual, w, atol=1e-2)
 
-  @pytest.mark.parametrize("optimizer", ["scipy", ScipyBatchOptimizer()])
-  def test_compile_scipy_optimizer(self, optimizer):
-    rank = 5
-    model_input = keras.Input(shape=(None, rank,), name="input")
-    model_output = keras.layers.Dense(
-      units=1,
-      input_shape=(rank,),
-      activation=None,
-      use_bias=False,
-      kernel_regularizer=L2(1e-3),
-      kernel_initializer="normal",
-    )(model_input)
-    model = BatchOptimizedModel(
-      inputs=model_input,
-      outputs=model_output,
-    )
-    loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer=optimizer, run_eagerly=False)
-    assert model.fit == model.fit_batch
+    @pytest.mark.parametrize("optimizer", ["scipy", ScipyBatchOptimizer()])
+    def test_compile_scipy_optimizer(self, optimizer):
+        rank = 5
+        model_input = keras.Input(
+            shape=(
+                None,
+                rank,
+            ),
+            name="input",
+        )
+        model_output = keras.layers.Dense(
+            units=1,
+            input_shape=(rank,),
+            activation=None,
+            use_bias=False,
+            kernel_regularizer=L2(1e-3),
+            kernel_initializer="normal",
+        )(model_input)
+        model = BatchOptimizedModel(
+            inputs=model_input,
+            outputs=model_output,
+        )
+        loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
+        model.compile(loss=loss, optimizer=optimizer, run_eagerly=False)
+        assert model.fit == model.fit_batch
 
-    np.random.seed(1)
-    w = np.random.normal(size=rank)
-    X = np.random.normal(size=(1000, rank))
-    y = np.expand_dims(X.dot(w), axis=1)
-    dataset = tf.data.Dataset.from_tensors((X, y))
+        np.random.seed(1)
+        w = np.random.normal(size=rank)
+        X = np.random.normal(size=(1000, rank))
+        y = np.expand_dims(X.dot(w), axis=1)
+        dataset = tf.data.Dataset.from_tensors((X, y))
 
-    # Fit using a Dataset
-    model.fit(x=dataset, method="L-BFGS-B", epochs=20, validation_data=dataset, options={'ftol': 1e-9})
-    actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
-    assert np.allclose(actual, w, 1e-2)
+        # Fit using a Dataset
+        model.fit(
+            x=dataset,
+            method="L-BFGS-B",
+            epochs=20,
+            validation_data=dataset,
+            options={"ftol": 1e-9},
+        )
+        actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
+        assert np.allclose(actual, w, 1e-2)
 
-    #  Fit using raw numpy values
-    model.fit(x=X, y=y, method="L-BFGS-B", epochs=20, validation_data=dataset, options={'ftol': 1e-9})
-    actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
-    assert np.allclose(actual, w, 1e-2)
+        #  Fit using raw numpy values
+        model.fit(
+            x=X,
+            y=y,
+            method="L-BFGS-B",
+            epochs=20,
+            validation_data=dataset,
+            options={"ftol": 1e-9},
+        )
+        actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
+        assert np.allclose(actual, w, 1e-2)
 
 
 class TestBatchOptimizedSequentialModel:
+    def test_stochastic_optimizer(self):
+        """
+        Ensure that the standard keras fit() interface is used if the optimizer
+        provided to compile() is a standard (stochastic) optimizer.
+        """
+        rank = 5
+        model = BatchOptimizedSequentialModel()
+        model.add(
+            keras.layers.Dense(
+                units=1,
+                input_shape=(rank,),
+                activation=None,
+                use_bias=False,
+                kernel_regularizer=L2(1e-3),
+                kernel_initializer="ones",
+            )
+        )
+        loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
+        model.compile(loss=loss, optimizer="adam", run_eagerly=False)
+        assert model.fit != model.fit_batch
 
-  def test_stochastic_optimizer(self):
-    """
-    Ensure that the standard keras fit() interface is used if the optimizer
-    provided to compile() is a standard (stochastic) optimizer.
-    """
-    rank = 5
-    model = BatchOptimizedSequentialModel()
-    model.add(keras.layers.Dense(
-      units=1,
-      input_shape=(rank,),
-      activation=None,
-      use_bias=False,
-      kernel_regularizer=L2(1e-3),
-      kernel_initializer="ones",
-    ))
-    loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer="adam", run_eagerly=False)
-    assert model.fit != model.fit_batch
+        np.random.seed(1)
+        w = np.random.normal(size=rank)
+        X = np.random.normal(size=(1000, rank))
+        y = X.dot(w)
+        model.fit(X, y, epochs=200)
+        actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
+        assert np.allclose(actual, w, atol=1e-2)
 
-    np.random.seed(1)
-    w = np.random.normal(size=rank)
-    X = np.random.normal(size=(1000, rank))
-    y = X.dot(w)
-    model.fit(X, y, epochs=200)
-    actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
-    assert np.allclose(actual, w, atol=1e-2)
+    @pytest.mark.parametrize("optimizer", ["scipy", ScipyBatchOptimizer()])
+    def test_compile_scipy_optimizer(self, optimizer):
+        rank = 5
+        model = BatchOptimizedSequentialModel()
+        model.add(
+            keras.layers.Dense(
+                units=1,
+                input_shape=(rank,),
+                activation=None,
+                use_bias=False,
+                kernel_regularizer=L2(1e-3),
+                kernel_initializer="ones",
+            )
+        )
+        loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
+        model.compile(loss=loss, optimizer=optimizer, run_eagerly=False)
+        assert model.fit == model.fit_batch
 
-  @pytest.mark.parametrize("optimizer", ["scipy", ScipyBatchOptimizer()])
-  def test_compile_scipy_optimizer(self, optimizer):
-    rank = 5
-    model = BatchOptimizedSequentialModel()
-    model.add(keras.layers.Dense(
-      units=1,
-      input_shape=(rank,),
-      activation=None,
-      use_bias=False,
-      kernel_regularizer=L2(1e-3),
-      kernel_initializer="ones",
-    ))
-    loss = keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM)
-    model.compile(loss=loss, optimizer=optimizer, run_eagerly=False)
-    assert model.fit == model.fit_batch
+        np.random.seed(1)
+        w = np.random.normal(size=rank)
+        X = np.random.normal(size=(1000, rank))
+        y = np.expand_dims(X.dot(w), axis=1)
+        dataset = tf.data.Dataset.from_tensors((X, y))
 
-    np.random.seed(1)
-    w = np.random.normal(size=rank)
-    X = np.random.normal(size=(1000, rank))
-    y = np.expand_dims(X.dot(w), axis=1)
-    dataset = tf.data.Dataset.from_tensors((X, y))
+        # Fit using a Dataset
+        model.fit(
+            x=dataset,
+            method="L-BFGS-B",
+            epochs=20,
+            validation_data=dataset,
+            options={"ftol": 1e-9},
+        )
+        actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
+        assert np.allclose(actual, w, 1e-2)
 
-    # Fit using a Dataset
-    model.fit(x=dataset, method="L-BFGS-B", epochs=20, validation_data=dataset, options={'ftol': 1e-9})
-    actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
-    assert np.allclose(actual, w, 1e-2)
+        #  Fit using raw numpy values
+        model.fit(
+            x=X,
+            y=y,
+            method="L-BFGS-B",
+            epochs=20,
+            validation_data=dataset,
+            options={"ftol": 1e-9},
+        )
+        actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
+        assert np.allclose(actual, w, 1e-2)
 
-    #  Fit using raw numpy values
-    model.fit(x=X, y=y, method="L-BFGS-B", epochs=20, validation_data=dataset, options={'ftol': 1e-9})
-    actual = np.reshape(model.trainable_weights[0].numpy(), (1, -1))
-    assert np.allclose(actual, w, 1e-2)
+    def test_fit_keras_tuner(self):
+        if not HAS_KERAS_TUNER:
+            logging.error("keras_tuner was not installed; skipping test.")
+            return
 
-  def test_fit_keras_tuner(self):
-    if not HAS_KERAS_TUNER:
-      logging.error("keras_tuner was not installed; skipping test.")
-      return
+        keras.utils.set_random_seed(1)
+        np.random.seed(1)
+        rank = 20
 
-    keras.utils.set_random_seed(1)
-    np.random.seed(1)
-    rank = 20
+        def _build_model(hp):
+            model = BatchOptimizedSequentialModel()
+            model.add(
+                keras.layers.Dense(
+                    units=hp.Int("units", min_value=1, max_value=4, step=1),
+                    input_shape=(rank,),
+                    activation="sigmoid",
+                    kernel_initializer="normal",
+                )
+            )
+            model.add(
+                keras.layers.Dense(
+                    units=1,
+                    activation="sigmoid",
+                    kernel_initializer="ones",
+                )
+            )
+            loss = keras.losses.MeanSquaredError()
+            model.compile(
+                loss=loss,
+                optimizer="cg",
+                metrics=[keras.metrics.RootMeanSquaredError()],
+                run_eagerly=False,
+            )
+            return model
 
-    def _build_model(hp):
-      model = BatchOptimizedSequentialModel()
-      model.add(keras.layers.Dense(
-        units=hp.Int("units", min_value=1, max_value=4, step=1),
-        input_shape=(rank,),
-        activation="sigmoid",
-        kernel_initializer="normal",
-      ))
-      model.add(keras.layers.Dense(
-        units=1,
-        activation="sigmoid",
-        kernel_initializer="ones",
-      ))
-      loss = keras.losses.MeanSquaredError()
-      model.compile(
-        loss=loss,
-        optimizer="cg",
-        metrics=[keras.metrics.RootMeanSquaredError()],
-        run_eagerly=False,
-      )
-      return model
+        # Generate data from a high rank linear model (relative to # of units in hidden layer)
+        w = np.random.normal(size=rank)
+        X = np.random.normal(size=(1000, rank))
+        y = np.expand_dims(X.dot(w), axis=1)
+        dataset = tf.data.Dataset.from_tensors((X, y))
 
-    # Generate data from a high rank linear model (relative to # of units in hidden layer)
-    w = np.random.normal(size=rank)
-    X = np.random.normal(size=(1000, rank))
-    y = np.expand_dims(X.dot(w), axis=1)
-    dataset = tf.data.Dataset.from_tensors((X, y))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tuner = keras_tuner.RandomSearch(
+                hypermodel=_build_model,
+                objective=keras_tuner.Objective(
+                    "val_root_mean_squared_error", direction="min"
+                ),
+                max_trials=4,
+                directory=tmpdir,
+                overwrite=True,
+            )
+            # Perform a hyperparameter search
+            tuner.search(x=X, y=y, epochs=100, validation_data=dataset, verbose=1)
+            assert len(tuner.get_best_models()) > 0
+            best_params = tuner.get_best_hyperparameters()[0].values
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-      tuner = keras_tuner.RandomSearch(
-        hypermodel=_build_model,
-        objective=keras_tuner.Objective("val_root_mean_squared_error", direction="min"),
-        max_trials=4,
-        directory=tmpdir,
-        overwrite=True,
-      )
-      # Perform a hyperparameter search
-      tuner.search(x=X, y=y, epochs=100, validation_data=dataset, verbose=1)
-      assert len(tuner.get_best_models()) > 0
-      best_params = tuner.get_best_hyperparameters()[0].values
-
-      # In this contrived example, the best model should be
-      # the one with the highest degrees of freedom
-      assert best_params['units'] == 4
+            # In this contrived example, the best model should be
+            # the one with the highest degrees of freedom
+            assert best_params["units"] == 4

--- a/tests/kormos/test_optimizers.py
+++ b/tests/kormos/test_optimizers.py
@@ -32,191 +32,222 @@ from tensorflow.python.keras.engine import data_adapter
 import kormos.optimizers as kopt
 from kormos.optimizers import BatchOptimizer, ScipyBatchOptimizer
 
+
 def test_get():
-  with pytest.raises(ValueError):
-    kopt.get('invalid')
-  assert type(kopt.get('scipy')) is ScipyBatchOptimizer
-  assert type(kopt.get('L-BFGS-B')) is ScipyBatchOptimizer
-  assert type(kopt.get('l-bfgs-b')) is ScipyBatchOptimizer
+    with pytest.raises(ValueError):
+        kopt.get("invalid")
+    assert type(kopt.get("scipy")) is ScipyBatchOptimizer
+    assert type(kopt.get("L-BFGS-B")) is ScipyBatchOptimizer
+    assert type(kopt.get("l-bfgs-b")) is ScipyBatchOptimizer
+
 
 def _build_ols_model(
-  rank=3,
-  X=None,
-  sample_weight=None,
-  weights=None,
-  num_samples=1000,
-  reg_coeff=0.1,
-  **kwargs
+    rank=3,
+    X=None,
+    sample_weight=None,
+    weights=None,
+    num_samples=1000,
+    reg_coeff=0.1,
+    **kwargs,
 ):
-  w = weights if weights is not None else (1.0 + np.arange(rank))
-  X = X if X is not None else np.random.normal(size=(num_samples, rank))
-  y = X.dot(w)
-  sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
-  dataset = (tf.convert_to_tensor(X), tf.convert_to_tensor(y), tf.convert_to_tensor(sample_weight))
+    w = weights if weights is not None else (1.0 + np.arange(rank))
+    X = X if X is not None else np.random.normal(size=(num_samples, rank))
+    y = X.dot(w)
+    sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+    dataset = (
+        tf.convert_to_tensor(X),
+        tf.convert_to_tensor(y),
+        tf.convert_to_tensor(sample_weight),
+    )
 
-  model = keras.models.Sequential()
-  model.add(keras.layers.Dense(
-    units=1,
-    input_shape=(rank,),
-    activation=None,
-    use_bias=False,
-    kernel_regularizer=L2(reg_coeff),
-    kernel_initializer="ones",
-  ))
-  model.compile(**{
-    **{'loss': keras.losses.MeanSquaredError(), 'optimizer': 'adam'},
-    **kwargs
-  })
-  return model, dataset
+    model = keras.models.Sequential()
+    model.add(
+        keras.layers.Dense(
+            units=1,
+            input_shape=(rank,),
+            activation=None,
+            use_bias=False,
+            kernel_regularizer=L2(reg_coeff),
+            kernel_initializer="ones",
+        )
+    )
+    model.compile(
+        **{**{"loss": keras.losses.MeanSquaredError(), "optimizer": "adam"}, **kwargs}
+    )
+    return model, dataset
+
 
 def _build_mlp_model(train_size=(10, 3), **kwargs):
-  w = np.random.normal(size=train_size[-1])
-  X = tf.convert_to_tensor(np.random.normal(size=train_size), dtype=tf.dtypes.float64)
-  y = tf.convert_to_tensor((X.numpy().dot(w) > 0.25).astype(int), dtype=tf.dtypes.float64)
-  dataset = tf.data.Dataset.from_tensors(tensors=(X, y))
+    w = np.random.normal(size=train_size[-1])
+    X = tf.convert_to_tensor(np.random.normal(size=train_size), dtype=tf.dtypes.float64)
+    y = tf.convert_to_tensor(
+        (X.numpy().dot(w) > 0.25).astype(int), dtype=tf.dtypes.float64
+    )
+    dataset = tf.data.Dataset.from_tensors(tensors=(X, y))
 
-  model = keras.models.Sequential()
-  model.add(keras.layers.Dense(
-    units=2,
-    input_shape=(train_size[-1],),
-    activation='sigmoid',
-    use_bias=False,
-    kernel_regularizer=L1(0e-1),
-    kernel_initializer="ones",
-  ))
-  model.add(keras.layers.Dense(
-    units=1,
-    activation='sigmoid',
-    use_bias=False,
-    kernel_regularizer=L2(0e-1),
-    kernel_initializer="ones",
-  ))
-  model.compile(**{
-    **{'loss': keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM), 'optimizer': 'adam'},
-    **kwargs
-  })
-  return model, dataset
+    model = keras.models.Sequential()
+    model.add(
+        keras.layers.Dense(
+            units=2,
+            input_shape=(train_size[-1],),
+            activation="sigmoid",
+            use_bias=False,
+            kernel_regularizer=L1(0e-1),
+            kernel_initializer="ones",
+        )
+    )
+    model.add(
+        keras.layers.Dense(
+            units=1,
+            activation="sigmoid",
+            use_bias=False,
+            kernel_regularizer=L2(0e-1),
+            kernel_initializer="ones",
+        )
+    )
+    model.compile(
+        **{
+            **{
+                "loss": keras.losses.MeanSquaredError(
+                    reduction=keras.losses.Reduction.SUM
+                ),
+                "optimizer": "adam",
+            },
+            **kwargs,
+        }
+    )
+    return model, dataset
 
 
 class TestBatchOptimizer(object):
+    def test_grad_analytic(self):
+        rank = 3
+        reg_coeff = 0.1
+        w_true = 1.0 + np.arange(rank)
+        model, dataset = _build_ols_model(
+            rank, weights=w_true, X=np.ones((2, rank)), reg_coeff=reg_coeff
+        )
+        optimizer = BatchOptimizer(
+            dtype=tf.dtypes.float64,
+            batch_size=1,
+        ).build(model, dataset)
 
-  def test_grad_analytic(self):
-    rank = 3
-    reg_coeff = 0.1
-    w_true = 1.0 + np.arange(rank)
-    model, dataset = _build_ols_model(
-      rank, weights=w_true, X=np.ones((2, rank)), reg_coeff=reg_coeff
-    )
-    optimizer = BatchOptimizer(
-      dtype=tf.dtypes.float64,
-      batch_size=1,
-    ).build(model, dataset)
+        # Evaluate the expected values and the model at w = [1, 1, 1]
+        (X, y) = (dataset[0].numpy(), dataset[1].numpy())
+        w = np.ones(rank)
+        bias = 0.0
+        y_pred = X.dot(w) + bias
+        n = X.shape[0]
+        expected_loss = (1 / n) * (y - y_pred).dot(y - y_pred) + reg_coeff * w.dot(w)
+        expected_grad = (2 / n) * X.T.dot(y_pred - y) + 2 * (reg_coeff * w)
+        expected_hess = (2 / n) * X.T.dot(X) + 2 * reg_coeff * np.eye(rank)
 
-    # Evaluate the expected values and the model at w = [1, 1, 1]
-    (X, y) = (dataset[0].numpy(), dataset[1].numpy())
-    w = np.ones(rank)
-    bias = 0.0
-    y_pred = X.dot(w) + bias
-    n = X.shape[0]
-    expected_loss = (1 / n) * (y - y_pred).dot(y - y_pred) + reg_coeff * w.dot(w)
-    expected_grad = (2 / n) * X.T.dot(y_pred - y) + 2 * (reg_coeff * w)
-    expected_hess = (2 / n) * X.T.dot(X) + 2 * reg_coeff * np.eye(rank)
+        assert np.allclose(
+            optimizer.func(w), expected_loss
+        ), f"optimizer.func(w) = {optimizer.func(w)} != expected = {expected_loss}"
+        assert np.allclose(
+            optimizer.grad(w), expected_grad
+        ), f"optimizer.grad = {optimizer.grad(w)} did not match expected = {expected_grad}"
+        for k in range(rank):
+            p = np.eye(rank)[k]
+            assert np.allclose(
+                optimizer.hessp(w, p),
+                expected_hess[:, k],
+            ), f"optimizer.hessp for {p} = {optimizer.hessp(w, p)} did not match expected = {expected_hess[:, k]}"
 
-    assert np.allclose(optimizer.func(w), expected_loss), f"optimizer.func(w) = {optimizer.func(w)} != expected = {expected_loss}"
-    assert np.allclose(optimizer.grad(w), expected_grad), f"optimizer.grad = {optimizer.grad(w)} did not match expected = {expected_grad}"
-    for k in range(rank):
-      p = np.eye(rank)[k]
-      assert np.allclose(
-        optimizer.hessp(w, p),
-        expected_hess[:, k],
-      ), f"optimizer.hessp for {p} = {optimizer.hessp(w, p)} did not match expected = {expected_hess[:, k]}"
+    def test_grad_numeric(self):
+        tol = 1e-3
+        model, dataset = _build_mlp_model()
+        optimizer = BatchOptimizer(
+            dtype=tf.dtypes.float64,
+            batch_size=2,
+        ).build(model, dataset)
+        w0 = optimizer.get_weights()
+        np.random.seed(1)
+        x = np.random.normal(size=w0.shape)
+        epsilon = tol**2
+        err = opt.check_grad(optimizer.func, optimizer.grad, x, epsilon=epsilon)
+        if err > tol:
+            g_approx = opt.approx_fprime(x, optimizer.func, epsilon=epsilon)
+            g = optimizer.grad(x)
+            assert (
+                err <= tol
+            ), f"Analytical gradient and numerical gradient differ by {err} > {tol}:\n grad: {g}\ngrad_approx: {g_approx}"
 
-  def test_grad_numeric(self):
-    tol = 1e-3
-    model, dataset = _build_mlp_model()
-    optimizer = BatchOptimizer(
-      dtype=tf.dtypes.float64,
-      batch_size=2,
-    ).build(model, dataset)
-    w0 = optimizer.get_weights()
-    np.random.seed(1)
-    x = np.random.normal(size=w0.shape)
-    epsilon = tol**2
-    err = opt.check_grad(optimizer.func, optimizer.grad, x, epsilon=epsilon)
-    if err > tol:
-      g_approx = opt.approx_fprime(x, optimizer.func, epsilon=epsilon)
-      g = optimizer.grad(x)
-      assert err <= tol, f"Analytical gradient and numerical gradient differ by {err} > {tol}:\n grad: {g}\ngrad_approx: {g_approx}"
+    def test_hessp_numeric(self):
+        tol = 1e-4
+        model, dataset = _build_mlp_model()
+        optimizer = BatchOptimizer(
+            dtype=tf.dtypes.float64,
+            batch_size=2,
+        ).build(model, dataset)
+        x = np.array(0 * optimizer.get_weights() + 1.0, dtype=np.float64)
 
-  def test_hessp_numeric(self):
-    tol = 1e-4
-    model, dataset = _build_mlp_model()
-    optimizer = BatchOptimizer(
-      dtype=tf.dtypes.float64,
-      batch_size=2,
-    ).build(model, dataset)
-    x = np.array(0 * optimizer.get_weights() + 1.0, dtype=np.float64)
+        def _hess(x):
+            n = len(x)
+            H = np.zeros((n, n))
+            grad = lambda x: opt.approx_fprime(x, optimizer.func, epsilon=1e-5)
+            for k in range(n):
+                h_approx = opt.approx_fprime(x, lambda x: grad(x)[k], epsilon=1e-5)
+                H[k, :] = h_approx
+            return H
 
-    def _hess(x):
-      n = len(x)
-      H = np.zeros((n, n))
-      grad = lambda x: opt.approx_fprime(x, optimizer.func, epsilon=1e-5)
-      for k in range(n):
-        h_approx = opt.approx_fprime(x, lambda x: grad(x)[k], epsilon=1e-5)
-        H[k, :] = h_approx
-      return H
-
-    H = _hess(x)
-    p = np.zeros(len(x))
-    for k in range(len(p)):
-      p[k] = 1
-      Hp = H.dot(p)
-      hessp = optimizer.hessp(x, p)
-      p[k] = 0
-      assert np.allclose(Hp, hessp, atol=1e-2), f"hessp does not match numerical evaluation for k={k}:\nhessp:{hessp}\napprox: {Hp}"
+        H = _hess(x)
+        p = np.zeros(len(x))
+        for k in range(len(p)):
+            p[k] = 1
+            Hp = H.dot(p)
+            hessp = optimizer.hessp(x, p)
+            p[k] = 0
+            assert np.allclose(
+                Hp, hessp, atol=1e-2
+            ), f"hessp does not match numerical evaluation for k={k}:\nhessp:{hessp}\napprox: {Hp}"
 
 
 class TestScipyBatchOptimizer(object):
+    def test_fit_ols(self):
+        rank = 5
+        weights = 1 + np.arange(rank)
+        model, dataset = _build_ols_model(
+            rank,
+            weights=weights,
+            reg_coeff=1e-5,
+            loss=keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM),
+        )
+        optimizer = ScipyBatchOptimizer(
+            dtype=tf.dtypes.float64,
+            batch_size=2,
+        ).build(model, dataset)
+        actual = optimizer.minimize(
+            method="L-BFGS-B", epochs=20, options={"gtol": 1e-9, "ftol": 1e-6}
+        )
+        assert np.allclose(
+            actual, weights, atol=0.01, rtol=0
+        ), f"Best fit parameters {actual} did not match expected {weights}"
+        assert len(optimizer.results) == 1
+        assert all([r.success for r in optimizer.results])
 
-  def test_fit_ols(self):
-    rank = 5
-    weights = 1 + np.arange(rank)
-    model, dataset = _build_ols_model(
-      rank,
-      weights=weights,
-      reg_coeff=1e-5,
-      loss=keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM), 
-    )
-    optimizer = ScipyBatchOptimizer(
-      dtype=tf.dtypes.float64,
-      batch_size=2,
-    ).build(model, dataset)
-    actual = optimizer.minimize(method='L-BFGS-B', epochs=20, options={'gtol': 1e-9, 'ftol': 1e-6})
-    assert np.allclose(actual, weights, atol=0.01, rtol=0), \
-      f"Best fit parameters {actual} did not match expected {weights}"
-    assert len(optimizer.results) == 1
-    assert all([r.success for r in optimizer.results])
+    def test_fit_ols_multirun(self):
+        rank = 5
+        weights = 1 + np.arange(rank)
+        model, dataset = _build_ols_model(rank, weights=weights, reg_coeff=1e-5)
+        optimizer = ScipyBatchOptimizer(
+            dtype=tf.dtypes.float64,
+            batch_size=2,
+        ).build(model, dataset)
+        actual = optimizer.minimize(
+            method=["L-BFGS-B", "Newton-CG"],
+            epochs=[2, 5],
+            options=[{"gtol": 1e-9, "ftol": 1e-6}, {}],
+        )
+        assert np.allclose(
+            actual, weights, atol=0.01, rtol=0
+        ), f"Best fit parameters {actual} did not match expected {weights}"
+        assert len(optimizer.results) == 2
+        # We only check for the success flag in the final solver call,
+        # since we haven't run the first solver long enough to converge
+        assert optimizer.results[-1].success
 
-  def test_fit_ols_multirun(self):
-    rank = 5
-    weights = 1 + np.arange(rank)
-    model, dataset = _build_ols_model(rank, weights=weights, reg_coeff=1e-5)
-    optimizer = ScipyBatchOptimizer(
-      dtype=tf.dtypes.float64,
-      batch_size=2,
-    ).build(model, dataset)
-    actual = optimizer.minimize(
-      method=['L-BFGS-B', 'Newton-CG'],
-      epochs=[2, 5],
-      options=[{'gtol': 1e-9, 'ftol': 1e-6}, {}],
-    )
-    assert np.allclose(actual, weights, atol=0.01, rtol=0), \
-      f"Best fit parameters {actual} did not match expected {weights}"
-    assert len(optimizer.results) == 2
-    # We only check for the success flag in the final solver call,
-    # since we haven't run the first solver long enough to converge
-    assert optimizer.results[-1].success
-
-  def test_fit_ols_distributed(self):
-    with tf.distribute.MirroredStrategy().scope():
-      self.test_fit_ols()
+    def test_fit_ols_distributed(self):
+        with tf.distribute.MirroredStrategy().scope():
+            self.test_fit_ols()

--- a/tests/kormos/test_optimizers.py
+++ b/tests/kormos/test_optimizers.py
@@ -46,6 +46,7 @@ def _build_ols_model(
   weights=None,
   num_samples=1000,
   reg_coeff=0.1,
+  **kwargs
 ):
   w = weights if weights is not None else (1.0 + np.arange(rank))
   X = X if X is not None else np.random.normal(size=(num_samples, rank))
@@ -62,10 +63,13 @@ def _build_ols_model(
     kernel_regularizer=L2(reg_coeff),
     kernel_initializer="ones",
   ))
-  model.compile(loss=keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM_OVER_BATCH_SIZE), optimizer="adam")
+  model.compile(**{
+    **{'loss': keras.losses.MeanSquaredError(), 'optimizer': 'adam'},
+    **kwargs
+  })
   return model, dataset
 
-def _build_mlp_model(train_size=(10, 3)):
+def _build_mlp_model(train_size=(10, 3), **kwargs):
   w = np.random.normal(size=train_size[-1])
   X = tf.convert_to_tensor(np.random.normal(size=train_size), dtype=tf.dtypes.float64)
   y = tf.convert_to_tensor((X.numpy().dot(w) > 0.25).astype(int), dtype=tf.dtypes.float64)
@@ -73,27 +77,28 @@ def _build_mlp_model(train_size=(10, 3)):
 
   model = keras.models.Sequential()
   model.add(keras.layers.Dense(
-    units=3,
+    units=2,
     input_shape=(train_size[-1],),
     activation='sigmoid',
     use_bias=False,
-    kernel_regularizer=L1(1e-1),
+    kernel_regularizer=L1(0e-1),
     kernel_initializer="ones",
   ))
   model.add(keras.layers.Dense(
     units=1,
     activation='sigmoid',
     use_bias=False,
-    kernel_regularizer=L2(1e-1),
+    kernel_regularizer=L2(0e-1),
     kernel_initializer="ones",
   ))
-  model.compile(loss=keras.losses.BinaryCrossentropy(), optimizer="adam")
+  model.compile(**{
+    **{'loss': keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM), 'optimizer': 'adam'},
+    **kwargs
+  })
   return model, dataset
 
 
 class TestBatchOptimizer(object):
-
-  keras.backend.set_floatx("float64")
 
   def test_grad_analytic(self):
     rank = 3
@@ -117,7 +122,7 @@ class TestBatchOptimizer(object):
     expected_grad = (2 / n) * X.T.dot(y_pred - y) + 2 * (reg_coeff * w)
     expected_hess = (2 / n) * X.T.dot(X) + 2 * reg_coeff * np.eye(rank)
 
-    assert optimizer.func(w) == expected_loss, f"optimizer.func(w) = {optimizer.func(w)} != expected = {expected_loss}"
+    assert np.allclose(optimizer.func(w), expected_loss), f"optimizer.func(w) = {optimizer.func(w)} != expected = {expected_loss}"
     assert np.allclose(optimizer.grad(w), expected_grad), f"optimizer.grad = {optimizer.grad(w)} did not match expected = {expected_grad}"
     for k in range(rank):
       p = np.eye(rank)[k]
@@ -127,16 +132,19 @@ class TestBatchOptimizer(object):
       ), f"optimizer.hessp for {p} = {optimizer.hessp(w, p)} did not match expected = {expected_hess[:, k]}"
 
   def test_grad_numeric(self):
-    tol = 1e-4
+    tol = 1e-3
     model, dataset = _build_mlp_model()
     optimizer = BatchOptimizer(
       dtype=tf.dtypes.float64,
       batch_size=2,
     ).build(model, dataset)
-    x = np.array(0 * optimizer.get_weights() + 1.0, dtype=np.float64)
-    err = opt.check_grad(optimizer.func, optimizer.grad, x)
+    w0 = optimizer.get_weights()
+    np.random.seed(1)
+    x = np.random.normal(size=w0.shape)
+    epsilon = tol**2
+    err = opt.check_grad(optimizer.func, optimizer.grad, x, epsilon=epsilon)
     if err > tol:
-      g_approx = opt.approx_fprime(x, optimizer.func, epsilon=1e-7)
+      g_approx = opt.approx_fprime(x, optimizer.func, epsilon=epsilon)
       g = optimizer.grad(x)
       assert err <= tol, f"Analytical gradient and numerical gradient differ by {err} > {tol}:\n grad: {g}\ngrad_approx: {g_approx}"
 
@@ -164,18 +172,21 @@ class TestBatchOptimizer(object):
       p[k] = 1
       Hp = H.dot(p)
       hessp = optimizer.hessp(x, p)
-      assert np.allclose(Hp, hessp, atol=1e-2), f"hessp does not match numerical evaluation for k={k}:\nhessp:{hessp}\napprox: {Hp}"
       p[k] = 0
+      assert np.allclose(Hp, hessp, atol=1e-2), f"hessp does not match numerical evaluation for k={k}:\nhessp:{hessp}\napprox: {Hp}"
 
 
 class TestScipyBatchOptimizer(object):
 
-  keras.backend.set_floatx("float64")
-
   def test_fit_ols(self):
     rank = 5
     weights = 1 + np.arange(rank)
-    model, dataset = _build_ols_model(rank, weights=weights, reg_coeff=1e-5)
+    model, dataset = _build_ols_model(
+      rank,
+      weights=weights,
+      reg_coeff=1e-5,
+      loss=keras.losses.MeanSquaredError(reduction=keras.losses.Reduction.SUM), 
+    )
     optimizer = ScipyBatchOptimizer(
       dtype=tf.dtypes.float64,
       batch_size=2,
@@ -205,3 +216,7 @@ class TestScipyBatchOptimizer(object):
     # We only check for the success flag in the final solver call,
     # since we haven't run the first solver long enough to converge
     assert optimizer.results[-1].success
+
+  def test_fit_ols_distributed(self):
+    with tf.distribute.MirroredStrategy().scope():
+      self.test_fit_ols()

--- a/tests/kormos/utils/test_cache.py
+++ b/tests/kormos/utils/test_cache.py
@@ -24,57 +24,56 @@ import numpy as np
 
 from kormos.utils.cache import OptimizationStateCache
 
-  
+
 class TestOptimizationStateCache(object):
+    def test_hash(self):
+        assert OptimizationStateCache.hash(np.zeros(0)) == "0x0"
+        eps = np.finfo(np.float128).eps
+        x1 = np.ones(10) + np.random.random(10)
+        x2 = x1.copy()
+        x3 = x1 + np.finfo(np.float64).eps * np.ones(x1.shape)
+        x4 = x1 + (eps / 2)
+        assert OptimizationStateCache.hash(x1) == OptimizationStateCache.hash(x2)
+        assert OptimizationStateCache.hash(x1) != OptimizationStateCache.hash(x3)
+        assert OptimizationStateCache.hash(x1) == OptimizationStateCache.hash(x4)
 
-  def test_hash(self):
-    assert OptimizationStateCache.hash(np.zeros(0)) == "0x0"
-    eps = np.finfo(np.float128).eps
-    x1 = np.ones(10) + np.random.random(10)
-    x2 = x1.copy()
-    x3 = x1 + np.finfo(np.float64).eps * np.ones(x1.shape)
-    x4 = x1 + (eps / 2)
-    assert OptimizationStateCache.hash(x1) == OptimizationStateCache.hash(x2)
-    assert OptimizationStateCache.hash(x1) != OptimizationStateCache.hash(x3)
-    assert OptimizationStateCache.hash(x1) == OptimizationStateCache.hash(x4)
+    def test_update(self):
+        fn = lambda x: x.sum()
+        n = 3
+        x = np.eye(n)
+        c = OptimizationStateCache(max_entries=(n - 1))
+        for k in range(n):
+            f = fn(x[k])
+            c.update(x[k], f=fn(x[k]))
+            assert c.get(x[k], "f") == f
+            assert c.get(x[k], "invalid") == None
 
-  def test_update(self):
-    fn = lambda x: x.sum()
-    n = 3
-    x = np.eye(n)
-    c = OptimizationStateCache(max_entries=(n - 1))
-    for k in range(n):
-      f = fn(x[k])
-      c.update(x[k], f=fn(x[k]))
-      assert c.get(x[k], 'f') == f
-      assert c.get(x[k], 'invalid') == None
-
-    assert c.get(x[0], 'f') == None
-    assert set(c.state_dict.keys()) == {c.hash(x[k]) for k in range(1, n)}
+        assert c.get(x[0], "f") == None
+        assert set(c.state_dict.keys()) == {c.hash(x[k]) for k in range(1, n)}
 
 
 class TestCachedDecorator(object):
 
-  # These should be instance variables but since pytest won't run calss suites
-  # with a constructor, we have to mickey mouse them here. This is (mostly)
-  # harmless since this class has no other purpose.
-  cache = OptimizationStateCache()
-  num_evals = 0
+    # These should be instance variables but since pytest won't run calss suites
+    # with a constructor, we have to mickey mouse them here. This is (mostly)
+    # harmless since this class has no other purpose.
+    cache = OptimizationStateCache()
+    num_evals = 0
 
-  @OptimizationStateCache.cached('cache_key')
-  def _cached_method(self, x):
-    self.num_evals += 1
-    return 2 * x
+    @OptimizationStateCache.cached("cache_key")
+    def _cached_method(self, x):
+        self.num_evals += 1
+        return 2 * x
 
-  def test_decorated_method(self):
-    assert self.cache.get(1, 'cache_key') == None
-    assert self.num_evals == 0
+    def test_decorated_method(self):
+        assert self.cache.get(1, "cache_key") == None
+        assert self.num_evals == 0
 
-    f = self._cached_method(1)
-    assert f == 2
-    assert self.cache.get(1, 'cache_key') == f
-    assert self.num_evals == 1
+        f = self._cached_method(1)
+        assert f == 2
+        assert self.cache.get(1, "cache_key") == f
+        assert self.num_evals == 1
 
-    f2 = self._cached_method(1)
-    assert f2 == f
-    assert self.num_evals == 1
+        f2 = self._cached_method(1)
+        assert f2 == f
+        assert self.num_evals == 1


### PR DESCRIPTION
## Summary

- This PR adds support for distribution strategies other than a single cpu/gpu on 1 machine
- The changes made here are mainly to convert the sums made over each mini-batch into a reduction over the replicas

## Reference Info

- https://www.tensorflow.org/guide/distributed_training#using_tfdistributestrategy_with_keras
- https://www.tensorflow.org/guide/distributed_training#use_tfdistributestrategy_with_custom_training_loops
- https://www.tensorflow.org/api_docs/python/tf/distribute/Strategy#experimental_distribute_dataset

## Issues that I found helpful while debugging

- https://github.com/keras-team/tf-keras/issues/505
- https://github.com/tensorflow/tensorflow/blob/v2.9.1/tensorflow/python/distribute/distribute_lib.py#L1672-L1858
- https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training.py#L2812